### PR TITLE
feat(dev-shell): enable Tailscale via service annotations

### DIFF
--- a/kubernetes/apps/develop/dev-shell/app/service.yaml
+++ b/kubernetes/apps/develop/dev-shell/app/service.yaml
@@ -3,9 +3,13 @@ apiVersion: v1
 kind: Service
 metadata:
   name: dev-shell
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "dev-shell"
   labels:
     app.kubernetes.io/name: dev-shell
     app.kubernetes.io/instance: dev-shell
+    tailscale.com/proxy-class: "tun-access"
 spec:
   type: ClusterIP
   ports:

--- a/kubernetes/apps/develop/dev-shell/app/statefulset.yaml
+++ b/kubernetes/apps/develop/dev-shell/app/statefulset.yaml
@@ -18,10 +18,6 @@ spec:
       labels:
         app.kubernetes.io/name: dev-shell
         app.kubernetes.io/instance: dev-shell
-      annotations:
-        tailscale.com/expose: "true"
-        tailscale.com/hostname: "dev-shell"
-        tailscale.com/tags: "tag:k8s"
     spec:
       securityContext:
         fsGroup: 1000


### PR DESCRIPTION
Move Tailscale exposure from non-functional pod annotations to the
Service, following the same pattern as Postgres and Satisfactory.
Adds tailscale.com/expose, tailscale.com/hostname, and the tun-access
proxy-class label so the operator creates a proxy for SSH access.

https://claude.ai/code/session_012izbNBXT6x278LcMaXv5c6