### PR TITLE
revert: revert gitea 1.25.5 → 1.26.1 (b717f5d)

### DIFF
--- a/kubernetes/apps/develop/gitea/app/helmrelease.yaml
+++ b/kubernetes/apps/develop/gitea/app/helmrelease.yaml
@@ -28,7 +28,7 @@ spec:
       registry: "docker.io"
       repository: gitea/gitea
       # renovate: datasource=docker depName=gitea/gitea
-      tag: 1.26.1
+      tag: 1.25.5
       rootless: true
 
     ## Deployment configuration


### PR DESCRIPTION
Reverts commit b717f5d (`feat(container): update gitea 1.25.5 → 1.26.1`).

Rolls back the gitea HelmRelease in `kubernetes/apps/develop/gitea/app/helmrelease.yaml` from 1.26.1 back to 1.25.5.

---
_Generated by [Claude Code](https://claude.ai/code/session_015XhxZ1EaKLBJi2WqeCPRQc)_