### PR TITLE
chore: remove dead Python deps and fix broken justfile recipes

### DIFF
--- a/bootstrap/mod.just
+++ b/bootstrap/mod.just
@@ -14,7 +14,7 @@ default: talos k8s (kubeconfig "node") wait namespaces resources crds apps kubec
 talos:
     just log info "Running stage..." "stage" "$0"
     for n in {{ nodes }}; do \
-        if ! op=$(just talos apply-node "$n" --insecure 2>&1); then \
+        if ! op=$(just talos apply-generated "$n" --insecure 2>&1); then \
             if [[ "$op" == *"certificate required"* ]]; then \
                 just log info "Talos already configured, skipping apply of config" "stage" "$0" "node" "$n"; \
                 continue; \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-bcrypt==5.0.0
-cloudflare==5.0.0
-email-validator==2.3.0
-makejinja==2.8.2
-netaddr==1.3.0
-passlib==1.7.4

--- a/talos/mod.just
+++ b/talos/mod.just
@@ -9,10 +9,6 @@ controller := `talosctl config info -o yaml | yq -e '.endpoints[0]'`
 default:
     just -l talos
 
-[doc('Apply Talos config to a node')]
-apply-node node *args:
-    just talos render-config "{{ node }}" | talosctl -n "{{ node }}" apply-config -f /dev/stdin {{ args }}
-
 [doc('Download Talos machine image')]
 download-image version schematic:
     gum spin --title "Downloading Talos {{ version }} ..." -- \
@@ -21,20 +17,10 @@ download-image version schematic:
         "https://factory.talos.dev/image/{{ schematic }}/{{ version }}/metal-amd64.iso"
     just log info "Downloaded Talos" version "{{ version }}" schematic "{{ schematic }}"
 
-[doc('Generate schematic ID from Talos schematic')]
-gen-schematic-id:
-    curl -sX POST --data-binary @<(just template "{{ talos_dir }}/schematic.yaml.j2") "https://factory.talos.dev/schematics" | jq -r '.id'
-
 [doc('Reboot a node')]
 reboot-node node:
     gum confirm "Reboot node {{ node }}?" --default="No" && \
         talosctl -n {{ node }} reboot -m powercycle || exit 0
-
-[doc('Render Talos config for a node')]
-render-config node:
-    export IS_CONTROLLER="$(just talos machine-controller {{ node }})"; \
-    talosctl machineconfig patch <(just template "{{ talos_dir }}/machineconfig.yaml.j2") \
-        -p @<(just template "{{ talos_dir }}/nodes/{{ node }}.yaml.j2")
 
 [doc('Reset a node')]
 reset-node node:
@@ -50,9 +36,16 @@ shutdown-node node:
 upgrade-k8s version:
     talosctl -n "{{ controller }}" upgrade-k8s --to {{ version }}
 
-[doc('Upgrade Talos version on a node')]
+[doc('Upgrade Talos version on a node (requires gen-config to have been run)')]
 upgrade-node node:
-    talosctl -n "{{ node }}" upgrade -i "$(just talos machine-image)" -m powercycle --timeout=10m
+    #!/usr/bin/env bash
+    set -euo pipefail
+    config_file="{{ talos_dir }}/clusterconfig/home-kubernetes-{{ node }}.yaml"
+    if [[ ! -f "$config_file" ]]; then
+        just log fatal "Config file not found: $config_file. Run 'just talos gen-config' first."
+    fi
+    image=$(yq -r '.machine.install.image' "$config_file")
+    talosctl -n "{{ node }}" upgrade -i "$image" -m powercycle --timeout=10m
 
 # =============================================================================
 # Cluster Rebuild Recipes
@@ -181,11 +174,3 @@ rebuild:
 
     just log info "Bootstrapping cluster..."
     just talos bootstrap-cluster
-
-[private]
-machine-controller node:
-    just template "{{ talos_dir }}/nodes/{{ node }}.yaml.j2" | yq -e 'select(.machine) | (.machine.type == "controlplane") // ""'
-
-[private]
-machine-image:
-    just template "{{ talos_dir }}/machineconfig.yaml.j2" | yq -e 'select(.machine) | .machine.install.image'


### PR DESCRIPTION
Cherry-picked from `claude/explore-ios-codebase-Sxo6p` (the one commit that didn't make it into PR #1209 before the session ended).

## Changes

**`requirements.txt` — deleted**
All six packages (`bcrypt`, `cloudflare`, `email-validator`, `makejinja`, `netaddr`, `passlib`) were unused — no Python scripts exist in the repo, and `minijinja-cli` is a Rust binary, not the Python `makejinja` package. Renovate will no longer open PRs for these dead deps.

**`talos/mod.just` — remove broken recipes**
`apply-node`, `render-config`, `gen-schematic-id`, and the private `machine-controller`/`machine-image` helpers all depended on `.j2` template files that were never created after the repo was imported from another repo. Also fixes `upgrade-node` to derive the install image from the talhelper-generated clusterconfig instead of a missing template.

**`bootstrap/mod.just` — switch `apply-node` → `apply-generated`**
Matches the talhelper-based workflow now that the broken `apply-node` recipe is gone.

https://claude.ai/code/session_013r6feDwtsgj96fUks9gTFY

---
_Generated by [Claude Code](https://claude.ai/code/session_013r6feDwtsgj96fUks9gTFY)_