### PR TITLE
feat(dev-shell): install Ruby via mise during initialization

### DIFF
--- a/kubernetes/apps/develop/dev-shell/README.md
+++ b/kubernetes/apps/develop/dev-shell/README.md
@@ -20,8 +20,8 @@ ssh bluevulpine@localhost -p 2222
 The init script (`init-configmap.yaml`) runs before sshd on every pod start:
 
 - **Every start (fast):** `apk add zsh git curl shadow`
-- **Once (persisted to PVC):** oh-my-zsh → `~/.oh-my-zsh`, atuin → `~/.atuin`
-- Sets zsh as the default shell and wires atuin into `.zshrc`
+- **Once (persisted to PVC):** oh-my-zsh → `~/.oh-my-zsh`, atuin → `~/.atuin`, mise → `~/.local/bin/mise`, Ruby (latest) → `~/.local/share/mise/installs/ruby`
+- Sets zsh as the default shell and wires atuin and mise into `.zshrc`
 
 On first SSH in, run `atuin login` to connect shell history sync.
 

--- a/kubernetes/apps/develop/dev-shell/app/init-configmap.yaml
+++ b/kubernetes/apps/develop/dev-shell/app/init-configmap.yaml
@@ -43,3 +43,24 @@ data:
         echo "# Atuin shell history" >> "${ZSHRC}"
         echo '[[ -f ~/.atuin/bin/atuin ]] && eval "$(~/.atuin/bin/atuin init zsh)"' >> "${ZSHRC}"
     fi
+
+    # mise — version manager for dev tools, persists on PVC
+    if [ ! -f "${USER_HOME}/.local/bin/mise" ]; then
+        echo "[init] Installing mise..."
+        su -l -s /bin/sh "${USER}" -c \
+            'curl https://mise.run | sh'
+    fi
+
+    # Ruby via mise — installs once, persists on PVC
+    if [ ! -d "${USER_HOME}/.local/share/mise/installs/ruby" ]; then
+        echo "[init] Installing Ruby via mise..."
+        su -l -s /bin/sh "${USER}" -c \
+            'PATH="${HOME}/.local/bin:${PATH}" mise use -g ruby@latest'
+    fi
+
+    # Wire mise into .zshrc if not already present
+    if [ -f "${ZSHRC}" ] && ! grep -q "mise activate" "${ZSHRC}"; then
+        echo "" >> "${ZSHRC}"
+        echo "# mise version manager" >> "${ZSHRC}"
+        echo 'eval "$(~/.local/bin/mise activate zsh)"' >> "${ZSHRC}"
+    fi

--- a/kubernetes/apps/develop/dev-shell/app/statefulset.yaml
+++ b/kubernetes/apps/develop/dev-shell/app/statefulset.yaml
@@ -78,6 +78,8 @@ spec:
               value: "bluevulpine"
             - name: SUDO_ACCESS
               value: "true"
+            - name: USER_SHELL
+              value: /bin/zsh
             - name: DEBIAN_FRONTEND
               value: noninteractive
             - name: LANG


### PR DESCRIPTION
Add mise (version manager) and Ruby installation to the dev-shell init
script, following the same one-time/PVC-persisted pattern used for
oh-my-zsh and atuin. Mise is installed if absent, then used to install
ruby@latest; both are wired into .zshrc on first run.

https://claude.ai/code/session_01PaYGFT8ZRyyUzZHQaZEKAN