### PR TITLE
fix(observability): resolve duplicate image key in kube-prometheus-stack thanos spec

### DIFF
--- a/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/helmrelease.yaml
@@ -113,8 +113,7 @@ spec:
           - memory-snapshot-on-shutdown
           - new-service-discovery-manager
         thanos:
-          image: quay.io/thanos/thanos:${THANOS_VERSION:=temp}
-          version: "${THANOS_VERSION#v:=temp}"
+          version: "${THANOS_VERSION:=temp}"
           objectStorageConfig:
             existingSecret:
               name: *secret


### PR DESCRIPTION
kube-prometheus-stack 84.5.0 introduced a template bug where the thanos
sidecar image key is rendered twice: first explicitly via a `with` block,
then again via `toYaml` of the full thanos map (image is not omitted).
This causes a YAML parse error in the Helm post-render step.

Remove the `image:` field so neither render path fires, letting
prometheus-operator construct `quay.io/thanos/thanos:{version}` from the
`version:` field. Also fix the invalid Flux envsubst expression
`${THANOS_VERSION#v:=temp}` (combining prefix-strip with default is not
supported); ThanosSpec.version accepts the full `v0.41.0` form directly.

https://claude.ai/code/session_01NiZ6sAV7TJenGgU7mmHzjY