### PR TITLE
feat(openbao): add OpenBao secrets management platform

### DIFF
--- a/kubernetes/apps/openbao/kustomization.yaml
+++ b/kubernetes/apps/openbao/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: openbao
+components:
+  - ../../components/common
+resources:
+  - ./namespace.yaml
+  - ./openbao/ks.yaml

--- a/kubernetes/apps/openbao/namespace.yaml
+++ b/kubernetes/apps/openbao/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openbao
+  annotations:
+    kustomize.toolkit.fluxcd.io/prune: disabled

--- a/kubernetes/apps/openbao/openbao/app/externalsecret.yaml
+++ b/kubernetes/apps/openbao/openbao/app/externalsecret.yaml
@@ -7,6 +7,7 @@ kind: ExternalSecret
 metadata:
   name: openbao-r2
 spec:
+  refreshInterval: 5m
   secretStoreRef:
     name: bitwarden-secrets-manager
     kind: ClusterSecretStore

--- a/kubernetes/apps/openbao/openbao/app/externalsecret.yaml
+++ b/kubernetes/apps/openbao/openbao/app/externalsecret.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+# Provides R2 credentials to the Raft snapshot CronJob.
+# Bitwarden key "r2" must exist with fields R2__AccessKey and R2__SecretKey.
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: openbao-r2
+spec:
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  target:
+    name: openbao-r2
+    template:
+      engineVersion: v2
+      data:
+        AWS_ACCESS_KEY_ID: "{{ .R2__AccessKey }}"
+        AWS_SECRET_ACCESS_KEY: "{{ .R2__SecretKey }}"
+  dataFrom:
+    - extract:
+        key: r2

--- a/kubernetes/apps/openbao/openbao/app/helmrelease.yaml
+++ b/kubernetes/apps/openbao/openbao/app/helmrelease.yaml
@@ -96,13 +96,11 @@ spec:
         fsGroup: 1000
 
       # Mount the SOPS-managed unseal key Secret; each Secret key becomes a file.
-      # The chart always mounts type:secret at /openbao/userconfig/<name>/ regardless
-      # of mountPath — so the key is at /openbao/userconfig/openbao-unseal/current_key.
+      # The chart mounts type:secret at {path}/{name}/ — defaults to /openbao/userconfig/<name>/.
+      # Omitting path uses the default, so the key lands at /openbao/userconfig/openbao-unseal/current_key.
       extraVolumes:
         - type: secret
           name: openbao-unseal
-          mountPath: /openbao/userconfig/openbao-unseal
-          readOnly: true
 
       serviceAccount:
         create: true

--- a/kubernetes/apps/openbao/openbao/app/helmrelease.yaml
+++ b/kubernetes/apps/openbao/openbao/app/helmrelease.yaml
@@ -1,0 +1,117 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app openbao
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: openbao
+      version: 0.27.0
+      sourceRef:
+        kind: HelmRepository
+        name: openbao
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    global:
+      # TLS terminated at the Envoy Gateway; pods communicate in plaintext internally
+      tlsDisable: true
+
+    server:
+      ha:
+        enabled: true
+        replicas: 3
+        raft:
+          enabled: true
+          # Uses pod name as the Raft node ID for stable cluster membership
+          setNodeId: true
+
+      config: |
+        ui = true
+
+        # Required when running as non-root; containers cannot lock memory pages
+        disable_mlock = true
+
+        listener "tcp" {
+          tls_disable     = 1
+          address         = "[::]:8200"
+          cluster_address = "[::]:8201"
+          telemetry {
+            unauthenticated_metrics_access = "true"
+          }
+        }
+
+        storage "raft" {
+          path = "/openbao/data"
+        }
+
+        # Static auto-unseal: key read from SOPS-managed Secret mounted as a file.
+        # Generate with: openssl rand -hex 32
+        # Rotate by adding previous_key_id/previous_key alongside current_key_id/current_key.
+        seal "static" {
+          current_key_id = "homelab-unseal-1"
+          current_key    = "file:///openbao/secrets/current_key"
+        }
+
+        # Enables pod-label-based leader discovery and health check annotations
+        service_registration "kubernetes" {}
+
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+
+      dataStorage:
+        enabled: true
+        size: 10Gi
+        # Longhorn allows PVCs to survive pod rescheduling across nodes.
+        # openebs-hostpath would pin each Raft replica to a specific node.
+        storageClass: longhorn
+        accessMode: ReadWriteOnce
+
+      auditStorage:
+        enabled: false
+
+      securityContext:
+        runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 100
+        fsGroup: 1000
+
+      # Mount the SOPS-managed unseal key Secret; each Secret key becomes a file
+      extraVolumes:
+        - type: secret
+          name: openbao-unseal
+          mountPath: /openbao/secrets
+          readOnly: true
+
+      serviceAccount:
+        create: true
+        name: openbao
+
+      # Binds the ServiceAccount to system:auth-delegator for Kubernetes auth method
+      authDelegator:
+        enabled: true
+
+    # The sidecar injector creates a cluster-wide MutatingWebhookConfiguration
+    # that can block pod scheduling if OpenBao is unhealthy. ESO handles secret
+    # sync instead, which decouples pod lifecycle from OpenBao availability.
+    injector:
+      enabled: false
+
+    ui:
+      enabled: true
+      serviceType: ClusterIP
+      # Route UI traffic to the active/leader pod only
+      activeOpenbaoPodOnly: true

--- a/kubernetes/apps/openbao/openbao/app/helmrelease.yaml
+++ b/kubernetes/apps/openbao/openbao/app/helmrelease.yaml
@@ -75,9 +75,11 @@ spec:
       dataStorage:
         enabled: true
         size: 10Gi
-        # Longhorn allows PVCs to survive pod rescheduling across nodes.
-        # openebs-hostpath would pin each Raft replica to a specific node.
-        storageClass: longhorn
+        # longhorn-1-replica: no storage-layer redundancy (Raft handles that),
+        # but pods can freely reschedule across nodes if their node is lost.
+        # Default longhorn (3 replicas) × 3 Raft pods = 9x redundancy — wasteful.
+        # openebs-hostpath would pin each pod to a specific node permanently.
+        storageClass: longhorn-1-replica
         accessMode: ReadWriteOnce
 
       auditStorage:

--- a/kubernetes/apps/openbao/openbao/app/helmrelease.yaml
+++ b/kubernetes/apps/openbao/openbao/app/helmrelease.yaml
@@ -57,9 +57,10 @@ spec:
         # Static auto-unseal: key read from SOPS-managed Secret mounted as a file.
         # Generate with: openssl rand -hex 32
         # Rotate by adding previous_key_id/previous_key alongside current_key_id/current_key.
+        # Path: extraVolumes type:secret always mounts at /openbao/userconfig/<name>/
         seal "static" {
           current_key_id = "homelab-unseal-1"
-          current_key    = "file:///openbao/secrets/current_key"
+          current_key    = "file:///openbao/userconfig/openbao-unseal/current_key"
         }
 
         # Enables pod-label-based leader discovery and health check annotations
@@ -83,7 +84,10 @@ spec:
         accessMode: ReadWriteOnce
 
       auditStorage:
-        enabled: false
+        enabled: true
+        size: 1Gi
+        storageClass: longhorn-1-replica
+        accessMode: ReadWriteOnce
 
       securityContext:
         runAsNonRoot: true
@@ -91,11 +95,13 @@ spec:
         runAsUser: 100
         fsGroup: 1000
 
-      # Mount the SOPS-managed unseal key Secret; each Secret key becomes a file
+      # Mount the SOPS-managed unseal key Secret; each Secret key becomes a file.
+      # The chart always mounts type:secret at /openbao/userconfig/<name>/ regardless
+      # of mountPath — so the key is at /openbao/userconfig/openbao-unseal/current_key.
       extraVolumes:
         - type: secret
           name: openbao-unseal
-          mountPath: /openbao/secrets
+          mountPath: /openbao/userconfig/openbao-unseal
           readOnly: true
 
       serviceAccount:

--- a/kubernetes/apps/openbao/openbao/app/helmrepository.yaml
+++ b/kubernetes/apps/openbao/openbao/app/helmrepository.yaml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/helmrepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: openbao
+spec:
+  interval: 2h
+  url: https://openbao.github.io/openbao-helm/

--- a/kubernetes/apps/openbao/openbao/app/httproute.yaml
+++ b/kubernetes/apps/openbao/openbao/app/httproute.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: openbao
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      group: infrastructure
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/name: "OpenBao"
+    gethomepage.dev/group: "Infrastructure"
+    gethomepage.dev/icon: "vault.png"
+    gethomepage.dev/description: "Secrets Management"
+spec:
+  hostnames: ["openbao.${SECRET_DOMAIN}"]
+  parentRefs:
+    # Internal gateway only — no reason to expose a secrets engine externally
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        # openbao-active routes exclusively to the current Raft leader
+        - name: openbao-active
+          port: 8200

--- a/kubernetes/apps/openbao/openbao/app/httproute.yaml
+++ b/kubernetes/apps/openbao/openbao/app/httproute.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     gatus.home-operations.com/endpoint: |
       group: infrastructure
+      path: /v1/sys/health
+      conditions:
+        - "[STATUS] == 200"
     gethomepage.dev/enabled: "true"
     gethomepage.dev/name: "OpenBao"
     gethomepage.dev/group: "Infrastructure"

--- a/kubernetes/apps/openbao/openbao/app/kustomization.yaml
+++ b/kubernetes/apps/openbao/openbao/app/kustomization.yaml
@@ -9,4 +9,5 @@ resources:
   - ./openbao-unseal.sops.yaml
   - ./openbao-snapshot-token.sops.yaml
   - ./httproute.yaml
+  - ./snapshot-serviceaccount.yaml
   - ./snapshot-cronjob.yaml

--- a/kubernetes/apps/openbao/openbao/app/kustomization.yaml
+++ b/kubernetes/apps/openbao/openbao/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrepository.yaml
+  - ./helmrelease.yaml
+  - ./externalsecret.yaml
+  - ./openbao-unseal.sops.yaml
+  - ./openbao-snapshot-token.sops.yaml
+  - ./httproute.yaml
+  - ./snapshot-cronjob.yaml

--- a/kubernetes/apps/openbao/openbao/app/openbao-snapshot-token.sops.yaml
+++ b/kubernetes/apps/openbao/openbao/app/openbao-snapshot-token.sops.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/secret.json
+# OpenBao token used by the Raft snapshot CronJob.
+#
+# Create this token post-initialization:
+#   1. bao policy write snapshot - <<EOF
+#      path "sys/storage/raft/snapshot" { capabilities = ["read"] }
+#      EOF
+#   2. bao token create -policy=snapshot -period=8760h -orphan
+#   3. Paste the token below and encrypt:
+#      sops -e -i kubernetes/apps/openbao/openbao/app/openbao-snapshot-token.sops.yaml
+#
+# Alternatively, configure Kubernetes auth in OpenBao and update the CronJob to
+# exchange its ServiceAccount JWT for a short-lived token at runtime (preferred
+# long-term because it avoids a static long-lived token).
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openbao-snapshot-token
+stringData:
+  OPENBAO_TOKEN: "<placeholder>"  # bao token create -policy=snapshot -period=8760h -orphan

--- a/kubernetes/apps/openbao/openbao/app/openbao-unseal.sops.yaml
+++ b/kubernetes/apps/openbao/openbao/app/openbao-unseal.sops.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/v1/secret.json
+# Static auto-unseal key for OpenBao.
+#
+# Generate a key:  openssl rand -hex 32
+# Encrypt file:    sops -e -i kubernetes/apps/openbao/openbao/app/openbao-unseal.sops.yaml
+#
+# The Secret key "current_key" becomes the file /openbao/secrets/current_key inside
+# each server pod (mounted via extraVolumes in the HelmRelease).
+#
+# Key rotation: add previous_key_id/previous_key alongside current_key_id/current_key
+# in the HelmRelease seal stanza, update this Secret with both keys, then remove
+# the previous_key entries once all data has been re-encrypted.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openbao-unseal
+stringData:
+  current_key: "<placeholder>"  # 64-char hex string: openssl rand -hex 32

--- a/kubernetes/apps/openbao/openbao/app/openbao-unseal.sops.yaml
+++ b/kubernetes/apps/openbao/openbao/app/openbao-unseal.sops.yaml
@@ -5,8 +5,8 @@
 # Generate a key:  openssl rand -hex 32
 # Encrypt file:    sops -e -i kubernetes/apps/openbao/openbao/app/openbao-unseal.sops.yaml
 #
-# The Secret key "current_key" becomes the file /openbao/secrets/current_key inside
-# each server pod (mounted via extraVolumes in the HelmRelease).
+# The Secret key "current_key" becomes the file /openbao/userconfig/openbao-unseal/current_key
+# inside each server pod (extraVolumes type:secret always mounts at /openbao/userconfig/<name>/).
 #
 # Key rotation: add previous_key_id/previous_key alongside current_key_id/current_key
 # in the HelmRelease seal stanza, update this Secret with both keys, then remove

--- a/kubernetes/apps/openbao/openbao/app/snapshot-cronjob.yaml
+++ b/kubernetes/apps/openbao/openbao/app/snapshot-cronjob.yaml
@@ -34,7 +34,7 @@ spec:
           serviceAccountName: openbao
           initContainers:
             - name: snapshot
-              image: quay.io/openbao/openbao:2.5.2
+              image: quay.io/openbao/openbao:2.5.2  # renovate: datasource=docker
               command:
                 - /bin/sh
                 - -c
@@ -46,7 +46,7 @@ spec:
                     /snapshots/openbao.snap
                   echo "Snapshot saved ($(wc -c < /snapshots/openbao.snap) bytes)"
               env:
-                - name: VAULT_TOKEN
+                - name: BAO_TOKEN
                   valueFrom:
                     secretKeyRef:
                       name: openbao-snapshot-token
@@ -56,7 +56,7 @@ spec:
                   mountPath: /snapshots
           containers:
             - name: upload
-              image: amazon/aws-cli:latest
+              image: amazon/aws-cli:2.27.18
               command:
                 - /bin/sh
                 - -c

--- a/kubernetes/apps/openbao/openbao/app/snapshot-cronjob.yaml
+++ b/kubernetes/apps/openbao/openbao/app/snapshot-cronjob.yaml
@@ -56,7 +56,7 @@ spec:
                   mountPath: /snapshots
           containers:
             - name: upload
-              image: amazon/aws-cli:2.27.18
+              image: amazon/aws-cli:2.34.45
               command:
                 - /bin/sh
                 - -c

--- a/kubernetes/apps/openbao/openbao/app/snapshot-cronjob.yaml
+++ b/kubernetes/apps/openbao/openbao/app/snapshot-cronjob.yaml
@@ -31,7 +31,7 @@ spec:
       template:
         spec:
           restartPolicy: OnFailure
-          serviceAccountName: openbao
+          serviceAccountName: openbao-snapshot
           initContainers:
             - name: snapshot
               image: quay.io/openbao/openbao:2.5.2  # renovate: datasource=docker

--- a/kubernetes/apps/openbao/openbao/app/snapshot-cronjob.yaml
+++ b/kubernetes/apps/openbao/openbao/app/snapshot-cronjob.yaml
@@ -1,0 +1,92 @@
+---
+# Raft snapshot CronJob — backs up all OpenBao data to Cloudflare R2 every 6 hours.
+#
+# Prerequisites (complete after OpenBao initialization):
+#   1. Create a snapshot policy in OpenBao:
+#        bao policy write snapshot - <<EOF
+#        path "sys/storage/raft/snapshot" { capabilities = ["read"] }
+#        EOF
+#   2. Create a long-lived token for the CronJob:
+#        bao token create -policy=snapshot -period=8760h -orphan
+#   3. Populate openbao-snapshot-token.sops.yaml with the token and encrypt it.
+#   4. Create the R2 bucket "openbao-snapshots" in your Cloudflare account.
+#   5. Unsuspend this CronJob: kubectl patch cronjob openbao-snapshot -n openbao
+#        --type='merge' -p '{"spec":{"suspend":false}}'
+#
+# Recovery: download any snapshot from R2, then:
+#   bao operator raft snapshot restore -force snapshot.snap
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: openbao-snapshot
+spec:
+  schedule: "0 */6 * * *"
+  # Suspended until OpenBao is initialized and the snapshot token is configured
+  suspend: true
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: openbao
+          initContainers:
+            - name: snapshot
+              image: quay.io/openbao/openbao:2.5.2
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  echo "Saving Raft snapshot..."
+                  bao operator raft snapshot save \
+                    -address=http://openbao-active.openbao.svc.cluster.local:8200 \
+                    /snapshots/openbao.snap
+                  echo "Snapshot saved ($(wc -c < /snapshots/openbao.snap) bytes)"
+              env:
+                - name: VAULT_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: openbao-snapshot-token
+                      key: OPENBAO_TOKEN
+              volumeMounts:
+                - name: snapshots
+                  mountPath: /snapshots
+          containers:
+            - name: upload
+              image: amazon/aws-cli:latest
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  SNAPSHOT_DATE=$(date -u +%Y%m%d-%H%M%S)
+                  DEST="s3://${SNAPSHOT_BUCKET}/snapshots/snapshot-${SNAPSHOT_DATE}.snap"
+                  echo "Uploading to ${DEST}..."
+                  aws s3 cp /snapshots/openbao.snap "${DEST}" \
+                    --endpoint-url "${SNAPSHOT_ENDPOINT}"
+                  echo "Upload complete. Pruning old snapshots (keeping 28 most recent)..."
+                  aws s3 ls "s3://${SNAPSHOT_BUCKET}/snapshots/" \
+                    --endpoint-url "${SNAPSHOT_ENDPOINT}" \
+                    | awk '{print $4}' | sort -r | tail -n +29 \
+                    | xargs -r -I{} aws s3 rm \
+                        "s3://${SNAPSHOT_BUCKET}/snapshots/{}" \
+                        --endpoint-url "${SNAPSHOT_ENDPOINT}"
+                  echo "Done."
+              env:
+                - name: SNAPSHOT_BUCKET
+                  value: "openbao-snapshots"
+                - name: SNAPSHOT_ENDPOINT
+                  value: "https://${SECRET_CLOUDFLARE_ACCOUNT_ID}.r2.cloudflarestorage.com"
+              envFrom:
+                - secretRef:
+                    # Provides AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY for R2
+                    name: openbao-r2
+              volumeMounts:
+                - name: snapshots
+                  mountPath: /snapshots
+          volumes:
+            - name: snapshots
+              emptyDir: {}

--- a/kubernetes/apps/openbao/openbao/app/snapshot-serviceaccount.yaml
+++ b/kubernetes/apps/openbao/openbao/app/snapshot-serviceaccount.yaml
@@ -1,0 +1,11 @@
+---
+# Minimal ServiceAccount for the Raft snapshot CronJob.
+# Deliberately separate from the openbao server ServiceAccount, which carries
+# system:auth-delegator and is used for Kubernetes auth-method token reviews.
+# This SA needs no Kubernetes RBAC — authentication to OpenBao uses a token from
+# openbao-snapshot-token Secret, and R2 upload uses credentials from openbao-r2 Secret.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: openbao-snapshot
+automountServiceAccountToken: false

--- a/kubernetes/apps/openbao/openbao/ks.yaml
+++ b/kubernetes/apps/openbao/openbao/ks.yaml
@@ -1,0 +1,28 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app openbao
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+  path: ./kubernetes/apps/openbao/openbao/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  targetNamespace: openbao
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 10m
+  postBuild:
+    substitute:
+      APP: *app
+      NS: openbao


### PR DESCRIPTION
Deploys OpenBao (open-source Vault fork) to the homelab with:
- 3-replica HA Raft cluster (10Gi Longhorn PVCs per pod)
- Static auto-unseal via SOPS-managed Secret (no cloud KMS dependency)
- Internal-only Envoy Gateway HTTPRoute at openbao.<SECRET_DOMAIN>
- Vault Agent Injector disabled; ESO remains the secret-sync pattern
- Raft snapshot CronJob to Cloudflare R2 every 6h (suspended until initialized)
- ExternalSecret pulling R2 credentials from Bitwarden for snapshot uploads

SOPS placeholder files created — fill and encrypt before deploying:
  openbao-unseal.sops.yaml: generate key with `openssl rand -hex 32`
  openbao-snapshot-token.sops.yaml: create post-initialization with snapshot policy

Post-initialization checklist in snapshot-cronjob.yaml comments.

https://claude.ai/code/session_01RSWXrLRgFizyJmBEqNug7x