### PR TITLE
fix(external-dns-unifi): migrate webhook to chart-native provider.webhook values

### DIFF
--- a/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/helmrelease.yaml
@@ -22,14 +22,10 @@ spec:
     logLevel: debug
     provider:
       name: webhook
-      # webhook block intentionally omitted — sidecar is declared below as a
-      # native sidecar initContainer so Kubernetes waits for webhook readiness
-      # before starting external-dns, eliminating the startup race condition.
-    initContainers:
-      - name: webhook
-        image: ghcr.io/kashalls/external-dns-unifi-webhook:v0.8.2@sha256:7f0ddbbc83a36a2a9d762e25eef9cafcb3adf0493068a27d72ae71087eafe6f0
-        imagePullPolicy: IfNotPresent
-        restartPolicy: Always
+      webhook:
+        image:
+          repository: ghcr.io/kashalls/external-dns-unifi-webhook
+          tag: v0.8.2@sha256:7f0ddbbc83a36a2a9d762e25eef9cafcb3adf0493068a27d72ae71087eafe6f0
         env:
           - name: UNIFI_HOST
             value: https://10.0.10.1
@@ -43,10 +39,6 @@ spec:
               secretKeyRef:
                 name: *secret
                 key: EXTERNAL_DNS_UNIFI_PASS
-        ports:
-          - name: http-webhook
-            containerPort: 8080
-            protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
## Summary

- Chart v1.21.1 added a hard `fail` in `_helpers.tpl` when `provider.name=webhook` but `provider.webhook.image.repository` or `.tag` is unset — breaking `flux-local test` on all Renovate PRs touching this release
- Migrates webhook sidecar config from a custom `initContainers` block into the chart-native `provider.webhook.*` values (`image`, `env`, `livenessProbe`, `readinessProbe`)
- Removes the manual native-sidecar pattern (`restartPolicy: Always` initContainer); external-dns retries on webhook unavailability so the concurrent-start trade-off is acceptable

## Test plan

- [ ] `flux-local test` CI job passes on this PR
- [ ] Verify `external-dns-unifi` HelmRelease reconciles cleanly after merge
- [ ] Confirm DNS records for UniFi continue to sync post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)