### PR TITLE
fix(media): remove AMD GPU from jellyfin, pin bazarr to 1.5.6

### DIFF
--- a/kubernetes/apps/media/bazarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/bazarr/app/helmrelease.yaml
@@ -19,7 +19,8 @@ spec:
           app:
             image:
               repository: ghcr.io/home-operations/bazarr
-              tag: rolling
+              # renovate: datasource=docker depName=ghcr.io/home-operations/bazarr
+              tag: 1.5.6
             env:
               BAZARR__PORT: &port 6767
               TZ: "${TIMEZONE}"

--- a/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyfin/app/helmrelease.yaml
@@ -41,10 +41,8 @@ spec:
               requests:
                 cpu: 100m
                 memory: 512Mi
-                amd.com/gpu: 1
               limits:
                 memory: 4Gi
-                amd.com/gpu: 1
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
@@ -54,8 +52,6 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
         # 44 = video, 105 = kvm, 109 = render (for GPU access), 10000 = media
         supplementalGroups: [44, 105, 109, 10000]
-      nodeSelector:
-        feature.node.kubernetes.io/pci-0300_1002.present: "true"
     service:
       app:
         controller: jellyfin


### PR DESCRIPTION
## Summary

- **jellyfin**: removes the `amd.com/gpu: 1` resource claim and AMD GPU node selector that were causing an `UnexpectedAdmissionError` — tdarr holds the only AMD GPU on `brokkr02`, leaving no healthy device for jellyfin to allocate. The `/dev/dri` hostPath mount and render supplemental group are retained for DRI access.
- **bazarr**: pins image from `rolling` → `1.5.6` with a renovate annotation. The `rolling` tag recently pulled a Python 3.14 base image; bazarr only supports ≤3.13 and was crashing immediately after scheduler init (1676 restarts over 3 days).

## What changed

| App | File | Change |
|-----|------|--------|
| jellyfin | `kubernetes/apps/media/jellyfin/app/helmrelease.yaml` | Removed `amd.com/gpu: 1` from requests/limits and removed `nodeSelector` for `feature.node.kubernetes.io/pci-0300_1002.present` |
| bazarr | `kubernetes/apps/media/bazarr/app/helmrelease.yaml` | Changed `tag: rolling` → `tag: 1.5.6`, added renovate annotation |

## Reviewer notes

- Jellyfin still has the `/dev/dri` hostPath volume — software transcoding and DRI will work on any node that exposes the device. Hardware transcoding via the AMD GPU plugin won't be available until tdarr releases the GPU or a second GPU is added.
- Bazarr will resume auto-updates via renovate once merged; the `1.5.6` pin is just to get it off the broken rolling tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)