### PR TITLE
fix(app-template): enable SA token mounting for apps with k8s API RBAC

### DIFF
--- a/kubernetes/apps/develop/drone/app/helmrelease.yaml
+++ b/kubernetes/apps/develop/drone/app/helmrelease.yaml
@@ -18,6 +18,8 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     controllers:
       # Drone Server
       server:

--- a/kubernetes/apps/home/homepage/app/helmrelease.yaml
+++ b/kubernetes/apps/home/homepage/app/helmrelease.yaml
@@ -24,6 +24,7 @@ spec:
       homepage:
         enabled: true
     defaultPodOptions:
+      automountServiceAccountToken: true
       tolerations:
         - key: "node.kubernetes.io/low-power"
           operator: "Equal"

--- a/kubernetes/apps/observability/gatus/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/gatus/app/helmrelease.yaml
@@ -18,6 +18,8 @@ spec:
       strategy: rollback
       retries: 3
   values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
     controllers:
       gatus:
         type: deployment


### PR DESCRIPTION
## Summary

Prerequisite fix before merging the app-template v4 → v5 upgrade ([#1232](https://github.com/bluevulpine/flux-talos/pull/1232)).

**Breaking change in app-template v5**: `automountServiceAccountToken` now defaults to `false` on all pods. Three apps in this cluster have `ClusterRole`/`Role` bindings that require the SA token to be mounted at runtime — without this fix, they silently lose k8s API access after the chart upgrade.

| App | Why it needs the token |
|---|---|
| `home/homepage` | ClusterRole: reads namespaces, pods, nodes, services, ingresses, HTTPRoutes for dashboard widgets |
| `develop/drone` (runner controller) | Role: creates/deletes pods and secrets for CI pipeline execution |
| `observability/gatus` | ClusterRole: reads services, HTTPRoutes, Gateways, Ingresses for endpoint auto-discovery |

**Changes**: adds `automountServiceAccountToken: true` to `defaultPodOptions` (homepage: existing block; drone/gatus: new block).

No other of the 59 app-template apps need this — the remaining apps have no k8s API RBAC and gain a security improvement from the new default.

## Test plan

- [ ] Merge this PR before or alongside #1232
- [ ] Confirm homepage Kubernetes widgets still display after app-template upgrade
- [ ] Confirm drone runner can create pipeline pods after upgrade
- [ ] Confirm gatus continues auto-discovering new HTTPRoutes after upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)