### PR TITLE
fix(flux-system): use flat path for github-status-token PushSecret

### DIFF
--- a/kubernetes/apps/flux-system/github-status-pushsecret.yaml
+++ b/kubernetes/apps/flux-system/github-status-pushsecret.yaml
@@ -18,4 +18,4 @@ spec:
     - match:
         secretKey: token
         remoteRef:
-          remoteKey: shared/github-status-token-secret
+          remoteKey: github-status-token-secret


### PR DESCRIPTION
## Summary

- Changes `remoteKey` in `github-status-pushsecret.yaml` from `shared/github-status-token-secret` → `github-status-token-secret`
- All 59 other OpenBao seeder PushSecrets use flat paths; the `shared/` prefix was the only outlier and caused ESO v2.5.0 to fail with `error unmarshalling vault secret: invalid JSON format` on every sync attempt (confirmed ~357 failures over 40h)
- The `shared/` prefix adds no functional benefit in KV v2 — secrets are equally accessible at flat paths

## Test plan

- [ ] Confirm `github-status-token-secret-push` PushSecret in `flux-system` transitions to `Synced` after Flux reconciles
- [ ] Verify `bao kv get secret/github-status-token-secret` returns `{ token: <ghp_...> }` with `managed-by: external-secrets` metadata
- [ ] Note for follow-up: when `github-status-token` ExternalSecret is migrated from Bitwarden to OpenBao (post-phase-3), its `dataFrom.extract.key` will point to `github-status-token-secret` (flat) and the template should map `{{ .token }}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)