### PR TITLE
feat(phase3): migrate all app ExternalSecrets from Bitwarden to OpenBao

### DIFF
--- a/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/externalsecret.yaml
+++ b/kubernetes/apps/actions-runner-system/actions-runner-controller/runners/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name actions-runner-controller-auth-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/cert-manager/cert-manager/app/externalsecret.yaml
+++ b/kubernetes/apps/cert-manager/cert-manager/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name cert-manager-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name cloudnative-pg-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/database/couchdb/app/externalsecret.yaml
+++ b/kubernetes/apps/database/couchdb/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name couchdb-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/database/influxdb/app/externalsecret.yaml
+++ b/kubernetes/apps/database/influxdb/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name influxdb-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/develop/drone/app/externalsecret.yaml
+++ b/kubernetes/apps/develop/drone/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name drone-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/develop/gitea/app/externalsecret.yaml
+++ b/kubernetes/apps/develop/gitea/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name gitea-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name
@@ -45,7 +45,7 @@ metadata:
   name: &name gitea-oauth-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/develop/nexus/app/externalsecret.yaml
+++ b/kubernetes/apps/develop/nexus/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name nexus-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/download/autobrr/app/externalsecret.yaml
+++ b/kubernetes/apps/download/autobrr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name autobrr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/download/cross-seed/app/externalsecret.yaml
+++ b/kubernetes/apps/download/cross-seed/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name cross-seed-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/download/qbittorrent/app/externalsecret.yaml
+++ b/kubernetes/apps/download/qbittorrent/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name qbittorrent-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/download/sabnzbd/app/externalsecret.yaml
+++ b/kubernetes/apps/download/sabnzbd/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name sabnzbd-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/download/unpackerr/app/externalsecret.yaml
+++ b/kubernetes/apps/download/unpackerr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name unpackerr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/games/valheim/app/externalsecret.yaml
+++ b/kubernetes/apps/games/valheim/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name valheim-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/games/valheim/syncthing-secret/externalsecret.yaml
+++ b/kubernetes/apps/games/valheim/syncthing-secret/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: valheim-volsync-syncthing
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     # This secret is used for Flux substituteFrom in the main valheim ks.yaml

--- a/kubernetes/apps/home/frigate/app/externalsecret.yaml
+++ b/kubernetes/apps/home/frigate/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name frigate-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/home/homepage/app/externalsecret.yaml
+++ b/kubernetes/apps/home/homepage/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name homepage-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/home/mosquitto/app/externalsecret.yaml
+++ b/kubernetes/apps/home/mosquitto/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name mosquitto-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/identity/authentik/app/externalsecret.yaml
+++ b/kubernetes/apps/identity/authentik/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name authentik
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/infrastructure/smtp-relay/app/externalsecret.yaml
+++ b/kubernetes/apps/infrastructure/smtp-relay/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name smtp-relay
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/kube-system/talos-backup/app/externalsecret.yaml
+++ b/kubernetes/apps/kube-system/talos-backup/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name talos-s3-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/bazarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/bazarr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name bazarr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/immich/app/externalsecret.yaml
+++ b/kubernetes/apps/media/immich/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name immich-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/lidarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/lidarr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name lidarr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/notifiarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/notifiarr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name notifiarr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/plex/app/externalsecret.yaml
+++ b/kubernetes/apps/media/plex/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name plex-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/plex/kometa/externalsecret.yaml
+++ b/kubernetes/apps/media/plex/kometa/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name kometa-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/prowlarr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name prowlarr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/radarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/radarr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name radarr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/readarr-audiobooks/app/externalsecret.yaml
+++ b/kubernetes/apps/media/readarr-audiobooks/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name readarr-audiobooks-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/readarr-ebooks/app/externalsecret.yaml
+++ b/kubernetes/apps/media/readarr-ebooks/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name readarr-ebooks-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/recyclarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/recyclarr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name recyclarr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/rreading-glasses/app/externalsecret.yaml
+++ b/kubernetes/apps/media/rreading-glasses/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name rreading-glasses-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/sonarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/sonarr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name sonarr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/media/tdarr/app/externalsecret.yaml
+++ b/kubernetes/apps/media/tdarr/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name tdarr-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/network/cloudflare-tunnel/app/externalsecret.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name cloudflare-tunnel-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/network/external-dns/cloudflare/externalsecret.yaml
+++ b/kubernetes/apps/network/external-dns/cloudflare/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name external-dns-secret-cloudflare
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/network/external-dns/unifi/externalsecret.yaml
+++ b/kubernetes/apps/network/external-dns/unifi/externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: bitwarden-secrets-manager
+    name: openbao
 
   target:
     name: *name

--- a/kubernetes/apps/network/tailscale/app/externalsecret.yaml
+++ b/kubernetes/apps/network/tailscale/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name operator-oauth
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/observability/gatus/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/gatus/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name gatus-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/observability/grafana/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/grafana/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name grafana-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/kube-prometheus-stack/app/externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   secretStoreRef:
     kind: ClusterSecretStore
-    name: bitwarden-secrets-manager
+    name: openbao
   target:
     name: alertmanager-secret
     template:

--- a/kubernetes/apps/observability/thanos/app/externalsecret.yaml
+++ b/kubernetes/apps/observability/thanos/app/externalsecret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: thanos-bucket
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: thanos-bucket

--- a/kubernetes/apps/openbao/openbao/app/externalsecret.yaml
+++ b/kubernetes/apps/openbao/openbao/app/externalsecret.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   refreshInterval: 5m
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: openbao-r2

--- a/kubernetes/apps/productivity/atuin/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/atuin/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name atuin-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/productivity/homebox-companion/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/homebox-companion/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name homebox-companion-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/productivity/homebox/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/homebox/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name homebox-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/productivity/joplin-server/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/joplin-server/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name joplin-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/productivity/karakeep/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/karakeep/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name karakeep-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/productivity/mealie/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/mealie/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name mealie-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/productivity/n8n/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/n8n/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name n8n-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/productivity/nextcloud/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/nextcloud/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name nextcloud-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
 
   target:

--- a/kubernetes/apps/productivity/node-red/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/node-red/app/externalsecret.yaml
@@ -6,7 +6,7 @@ metadata:
   name: &name node-red-secret
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: *name

--- a/kubernetes/apps/volsync-system/kopia-maintenance/app/externalsecret-local.yaml
+++ b/kubernetes/apps/volsync-system/kopia-maintenance/app/externalsecret-local.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kopia-maintenance-local
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: kopia-maintenance-local-secret

--- a/kubernetes/apps/volsync-system/kopia-maintenance/app/externalsecret-r2.yaml
+++ b/kubernetes/apps/volsync-system/kopia-maintenance/app/externalsecret-r2.yaml
@@ -6,7 +6,7 @@ metadata:
   name: kopia-maintenance-r2
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: kopia-maintenance-r2-secret


### PR DESCRIPTION
## Summary

- Switches `secretStoreRef.name` from `bitwarden-secrets-manager` to `openbao` in all 55 app ExternalSecrets
- `dataFrom.extract.key` values and templates are unchanged — OpenBao paths mirror the Bitwarden item names (seeded by phase 2 PushSecrets)
- Depends on: phase 2 (#1271, merged) which deployed the 59 seeder PushSecrets and the `openbao` ClusterSecretStore

## Pre-merge checks (all passed)

- [x] All 59 PushSecrets in `external-secrets` namespace: `Synced`
- [x] OpenBao ClusterSecretStore `openbao`: `Valid` / `Ready`
- [x] OpenBao KV spot-checks (cloudnative-pg, r2, grafana, volsync-local-template): all fields present
- [x] Flux kustomization chain (`external-secrets-stores`, `external-secrets-openbao-seed`, `external-secrets-openbao-store`, `openbao`): all `Ready`
- [x] Exactly 55 ExternalSecret files changed, no drift from expected scope
- [x] `github-status-token` ExternalSecret unchanged (intentionally excluded — still on Bitwarden)

## Intentional exclusions (not in this PR)

- `sops-age` ExternalSecret — stays on `bitwarden-secrets-manager` permanently (bootstrapping constraint)
- `test-secret` ExternalSecret — test artifact, not consumed by anything
- `github-status-token` ExternalSecret — re-migrate after confirming `secret/github-status-token-secret` is seeded (tracked in #1279)

## Post-merge monitoring

After Flux reconciles (`flux reconcile kustomization cluster-apps -n flux-system` to fast-track), all 55 app ExternalSecrets should report `SecretSynced`. Any `SecretSyncedError` indicates a missing field in OpenBao for that path — check with `kubectl describe externalsecret <name> -n <ns>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)