### PR TITLE
feat(storage): scaffold tns-csi driver alongside democratic-csi

### DIFF
--- a/kubernetes/apps/kube-system/kustomization.yaml
+++ b/kubernetes/apps/kube-system/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ./namespace.yaml
   - ./certificates/ks.yaml
   - ./democratic-csi/ks.yaml
+  - ./tns-csi/ks.yaml
   # gateway-api-crds and gateway removed - now managed by Envoy Gateway in network namespace
   - ./cilium/ks.yaml
   - ./coredns/ks.yaml

--- a/kubernetes/apps/kube-system/tns-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/tns-csi/app/helmrelease.yaml
@@ -1,0 +1,131 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tns-csi
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: tns-csi-driver
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+  uninstall:
+    keepHistory: false
+  values:
+    truenas:
+      # Uses the modern WebSocket JSON-RPC API — no legacy REST, no alert flood.
+      url: "wss://${SECRET_NFS_SERVER}:443/api/current"
+      apiKey: "${DEMOCRATIC_CSI_API_KEY}"
+      # Set true if TrueNAS uses a self-signed certificate
+      skipTLSVerify: false
+
+    storageClasses:
+      # ── NFS ──────────────────────────────────────────────────────────────────
+      # ReadWriteMany; drop-in replacement for truenas-nfs once workloads migrate
+      - name: tns-csi-nfs
+        enabled: true
+        protocol: nfs
+        pool: "${TRUENAS_POOL}"
+        server: "${SECRET_NFS_SERVER}"
+        parentDataset: "tns-csi/nfs"
+        reclaimPolicy: Delete
+        volumeBindingMode: Immediate
+        allowVolumeExpansion: true
+        mountOptions:
+          - hard
+          - noatime
+          - noresvport
+          - nfsvers=4.2
+          - rsize=1048576
+          - wsize=1048576
+
+      # ── iSCSI ────────────────────────────────────────────────────────────────
+      # Block storage; iscsi-tools extension already present on all Talos nodes.
+      # ReadWriteOnce; drop-in replacement for truenas-iscsi once workloads migrate.
+      - name: tns-csi-iscsi
+        enabled: true
+        protocol: iscsi
+        pool: "${TRUENAS_POOL}"
+        server: "${SECRET_NFS_SERVER}"
+        parentDataset: "tns-csi/iscsi"
+        port: "3260"
+        fsType: xfs
+        reclaimPolicy: Delete
+        volumeBindingMode: Immediate
+        allowVolumeExpansion: true
+
+      # ── NVMe-oF ──────────────────────────────────────────────────────────────
+      # High-performance block storage over TCP. nvme_tcp kernel module is already
+      # loaded on all Talos nodes (confirmed in talconfig.yaml).
+      #
+      # TrueNAS-side prerequisites before enabling workloads here:
+      #   1. Enable NVMe-oF target service in TrueNAS SCALE
+      #   2. Create an NVMe subsystem and namespace pointing at the ZFS pool
+      #   3. Ensure port 4420/tcp is reachable from cluster nodes
+      - name: tns-csi-nvmeof
+        enabled: true
+        protocol: nvmeof
+        pool: "${TRUENAS_POOL}"
+        server: "${SECRET_NFS_SERVER}"
+        parentDataset: "tns-csi/nvmeof"
+        transport: tcp
+        port: "4420"
+        fsType: xfs
+        reclaimPolicy: Delete
+        volumeBindingMode: Immediate
+        allowVolumeExpansion: true
+
+      # ── SMB ──────────────────────────────────────────────────────────────────
+      # Disabled until you create the credential Secret and enable SMB in TrueNAS.
+      # To enable:
+      #   1. Enable SMB service in TrueNAS SCALE
+      #   2. Create a TrueNAS user with share access
+      #   3. kubectl create secret generic tns-csi-smb-credentials \
+      #        --from-literal=username=<user> \
+      #        --from-literal=password=<pass> \
+      #        -n kube-system
+      #   4. Set enabled: true below
+      - name: tns-csi-smb
+        enabled: false
+        protocol: smb
+        pool: "${TRUENAS_POOL}"
+        server: "${SECRET_NFS_SERVER}"
+        parentDataset: "tns-csi/smb"
+        smbCredentialsSecret:
+          name: tns-csi-smb-credentials
+          namespace: kube-system
+        reclaimPolicy: Delete
+        volumeBindingMode: Immediate
+        allowVolumeExpansion: true
+
+    snapshots:
+      enabled: true
+      volumeSnapshotClass:
+        create: true
+        deletionPolicy: Delete
+
+    controller:
+      tolerations:
+        - key: "node.kubernetes.io/low-power"
+          operator: "Equal"
+          value: "raspberry-pi"
+          effect: "NoSchedule"
+
+    node:
+      # Standard kubelet path for Talos Linux
+      kubeletPath: /var/lib/kubelet
+      tolerations:
+        - key: "node.kubernetes.io/low-power"
+          operator: "Equal"
+          value: "raspberry-pi"
+          effect: "NoSchedule"
+      iscsi:
+        # Keep enabled — siderolabs/iscsi-tools extension is installed on all nodes
+        enabled: true

--- a/kubernetes/apps/kube-system/tns-csi/app/kustomization.yaml
+++ b/kubernetes/apps/kube-system/tns-csi/app/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/kube-system/tns-csi/app/ocirepository.yaml
+++ b/kubernetes/apps/kube-system/tns-csi/app/ocirepository.yaml
@@ -1,0 +1,15 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: tns-csi-driver
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    # renovate: datasource=docker depName=registry-1.docker.io/bfenski/tns-csi-driver
+    tag: "0.17.5"
+  url: oci://registry-1.docker.io/bfenski/tns-csi-driver

--- a/kubernetes/apps/kube-system/tns-csi/ks.yaml
+++ b/kubernetes/apps/kube-system/tns-csi/ks.yaml
@@ -1,0 +1,29 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app tns-csi
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    - name: external-secrets-stores
+      namespace: external-secrets
+    - name: snapshot-controller
+  path: ./kubernetes/apps/kube-system/tns-csi/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  targetNamespace: kube-system
+  wait: true
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      NS: kube-system

--- a/kubernetes/components/common/cluster-config/cluster-settings.yaml
+++ b/kubernetes/components/common/cluster-config/cluster-settings.yaml
@@ -5,6 +5,8 @@ metadata:
   name: cluster-settings
 data:
   TIMEZONE: "America/Chicago"
+  # ZFS pool name on TrueNAS (verify: dcsi uses 'apps/democratic-csi/...' so pool is likely 'apps')
+  TRUENAS_POOL: "apps"
   SVC_K8S_API_ADDR: 172.16.8.1
   SVC_NGINX_INTERNAL: 172.16.8.2
   SVC_NGINX_EXTERNAL: 172.16.8.3


### PR DESCRIPTION
Adds tns-csi (tns.csi.io provisioner) as a second CSI driver that uses
the modern TrueNAS WebSocket JSON-RPC API, eliminating the legacy REST
API alert flood from democratic-csi's freenas-api-* drivers.

Both drivers coexist cleanly — provisioner names are distinct so existing
dcsi PVs and StorageClasses are untouched until workloads are manually
migrated via volsync.

Scaffolds StorageClasses for all four protocols:
- tns-csi-nfs: NFS 4.2, ReadWriteMany, mirrors truenas-nfs mount options
- tns-csi-iscsi: iSCSI/XFS, ReadWriteOnce; iscsi-tools already on all nodes
- tns-csi-nvmeof: NVMe-oF/TCP/XFS; nvme_tcp module already loaded on all nodes
- tns-csi-smb: disabled pending credential Secret and TrueNAS SMB setup

Reuses DEMOCRATIC_CSI_API_KEY and SECRET_NFS_SERVER from cluster-secrets.
Adds TRUENAS_POOL to cluster-settings (inferred as 'apps' from dcsi dataset
paths — verify before reconciling).

https://claude.ai/code/session_01VxXd7eHqtxMnwLejPwBYXD