### PR TITLE
feat(phase4): migrate github-status ExternalSecret to OpenBao

### DIFF
--- a/kubernetes/components/common/alerts/github-status/externalsecret.yaml
+++ b/kubernetes/components/common/alerts/github-status/externalsecret.yaml
@@ -6,13 +6,13 @@ metadata:
   name: github-status-token
 spec:
   secretStoreRef:
-    name: bitwarden-secrets-manager
+    name: openbao
     kind: ClusterSecretStore
   target:
     name: github-status-token-secret
     template:
       data:
-        token: "{{ .Flux__GithubToken }}"
+        token: "{{ .token }}"
   dataFrom:
     - extract:
-        key: flux
+        key: github-status-token-secret


### PR DESCRIPTION
## Summary

Final Phase 4 step: switches the `github-status-token` ExternalSecret from Bitwarden Secrets Manager to OpenBao.

The token was seeded into OpenBao at `github-status-token-secret` by the `github-status-token-secret-push` PushSecret, which confirmed `Synced successfully` after the `secretKey` bug fix in PR #1284. The Bitwarden seeder PushSecret remains in place.

## Test plan

- [ ] `github-status-token` ExternalSecret shows `SecretSynced` from OpenBao
- [ ] Flux GitHub status notifications continue working

🤖 Generated with [Claude Code](https://claude.com/claude-code)