### PR TITLE
fix(jellyseerr): add startup probe to prevent restart loops on boot

### DIFF
--- a/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
@@ -38,6 +38,17 @@ spec:
                   timeoutSeconds: 1
                   failureThreshold: 3
               readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /api/v1/status
+                    port: *port
+                  initialDelaySeconds: 0
+                  periodSeconds: 5
+                  timeoutSeconds: 1
+                  failureThreshold: 12
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary

- Adds a `startupProbe` on `/api/v1/status` (12×5s = 60s max window) before liveness/readiness probes engage
- Without this, the liveness probe (0s initial delay, 3 failures × 10s = 30s window) can fire during Jellyseerr's initialization and trigger an unnecessary restart loop
- Verified against the live cluster: no startup probe is currently configured

## Test plan

- [ ] Flux reconciles the HelmRelease without errors
- [ ] Pod starts cleanly — startup probe passes before liveness/readiness begin cycling
- [ ] Confirm no CrashLoopBackOff on the next rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)