### PR TITLE
fix(homebox): re-pin working digest (new build requires HBOX_AUTH_API_KEY_PEPPER)

### DIFF
--- a/kubernetes/apps/productivity/homebox/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/homebox/app/helmrelease.yaml
@@ -36,7 +36,7 @@ spec:
             image:
               repository: ghcr.io/sysadminsmedia/homebox
               # renovate: datasource=docker depName=ghcr.io/sysadminsmedia/homebox
-              tag: latest@sha256:b1ad7e3c63f732a5f6daa466e8116be4f545b3b120383a64dcb62beb00a660cc
+              tag: latest@sha256:6506480a3dfadd2cc885fa97b32d11b0ee28ec58629fa34a76afdb4ac540c7fc
             env:
               TZ: "${TIMEZONE}"
               # Temp directory must be on same filesystem as /data for file uploads


### PR DESCRIPTION
Renovate #1363 bumped homebox's `latest` digest to a new build that makes `auth.api_key_pepper` mandatory; the container panics on startup and crash-looped homebox.

Re-pinning to the previous working digest (`6506480`) to restore service. The version upgrade is deferred until `HBOX_AUTH_API_KEY_PEPPER` is provisioned (generate 32+ bytes → OpenBao `homebox` key → ESO template).

🤖 Generated with [Claude Code](https://claude.com/claude-code)