### PR TITLE
fix(renovate): drop duplicate gitea helm-values dep

### DIFF
--- a/.renovate/overrides.json5
+++ b/.renovate/overrides.json5
@@ -25,5 +25,17 @@
       matchPackageNames: ["simonhaas/tailscale-node-remover"],
       enabled: false,
     },
+    {
+      // gitea is the only release with both an explicit `registry: docker.io`
+      // field and a `# renovate:` annotation, so the built-in helm-values
+      // manager (depName docker.io/gitea/gitea) and the customManager
+      // (depName gitea/gitea) both match the same tag line and Renovate opens
+      // two PRs for a single update. The annotation is the repo convention, so
+      // drop the redundant helm-values-detected duplicate.
+      description: "Gitea: drop helm-values duplicate; image tracked via the # renovate annotation",
+      matchManagers: ["helm-values"],
+      matchPackageNames: ["docker.io/gitea/gitea"],
+      enabled: false,
+    },
   ],
 }


### PR DESCRIPTION
gitea is the only release with both an explicit `registry: docker.io` field and a `# renovate:` annotation, so Renovate's built-in helm-values manager (`docker.io/gitea/gitea`) and the customManager annotation (`gitea/gitea`) both match the same `tag:` line — producing two PRs for a single update (e.g. #1385 and #1386).

This disables the redundant helm-values-detected dep, keeping the repo's `# renovate:` annotation as the single source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)