### PR TITLE
fix(dragonfly): grant operator RBAC for poddisruptionbudgets

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/rbac.yaml
+++ b/kubernetes/apps/database/dragonfly/app/rbac.yaml
@@ -31,6 +31,13 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  # poddisruptionbudgets required since operator v1.6.x: the controller now
+  # provisions a PDB per Dragonfly cluster. Without list/watch its informer
+  # cache never syncs, crashlooping the operator (observed: 1400+ restarts) so
+  # it silently stops reconciling — spec image bumps never roll the StatefulSet.
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
## Problem

The `dragonfly-operator` (v1.6.x) provisions a PodDisruptionBudget per Dragonfly cluster, but its hand-maintained `ClusterRole` (`kubernetes/apps/database/dragonfly/app/rbac.yaml`) lacked `policy/poddisruptionbudgets` access.

Without list/watch, the PDB informer cache never syncs and crashloops the operator (observed **1400+ restarts** on a replica). The operator silently stops reconciling: CR spec image bumps were applied to the `Dragonfly` CR but **never rolled the StatefulSet**, leaving the data pods stuck on `v1.36.0` while git had advanced through `v1.38.1` → `v1.39.0`.

Observed operator log:
```
Failed to watch *v1.PodDisruptionBudget: poddisruptionbudgets.policy is forbidden:
User "system:serviceaccount:database:dragonfly-operator" cannot list resource
"poddisruptionbudgets" in API group "policy" at the cluster scope
```

## Fix

Add the `policy/poddisruptionbudgets` rule, mirroring the [upstream operator role](https://github.com/dragonflydb/dragonfly-operator/blob/v1.6.1/manifests/dragonfly-operator.yaml) verb set. Same class of fix as the earlier `configmaps` addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)