### PR TITLE
fix(dragonfly): label operator pods control-plane=controller-manager

### DIFF
--- a/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
+++ b/kubernetes/apps/database/dragonfly/app/helmrelease.yaml
@@ -66,6 +66,15 @@ spec:
               readOnlyRootFilesystem: true
               capabilities: { drop: ["ALL"] }
         pod:
+          # The operator generates a NetworkPolicy (owned by the Dragonfly CR)
+          # that only admits the admin port 9999 from pods labelled
+          # control-plane=controller-manager — the label upstream's kustomize
+          # deployment uses. This chart (app-template) labels pods
+          # app.kubernetes.io/name=dragonfly-operator instead, so without this
+          # the operator cannot reach 9999 to verify pod readiness, stalling
+          # every rolling update with an orphaned (role-less) replica.
+          labels:
+            control-plane: controller-manager
           automountServiceAccountToken: true
           securityContext:
             runAsUser: 65534


### PR DESCRIPTION
## Problem

Follow-up to #1390. With the PDB RBAC fixed, the operator resumed rolling updates but stalls mid-roll: it cannot verify readiness of rolled pods.

```
ERROR DragonflyPodLifecycle ... failed to verify pod readiness:
failed to determine dataset load status: dial tcp <podIP>:9999: i/o timeout
```

The operator generates a NetworkPolicy (owned by the `Dragonfly` CR) that only admits the admin port **9999** from pods labelled `control-plane=controller-manager` — the label upstream's kustomize deployment uses. This repo installs the operator via the **app-template** chart, which labels pods `app.kubernetes.io/name=dragonfly-operator` instead. No pod carries `control-plane=controller-manager`, so the operator's own connection to port 9999 is blocked by the NetworkPolicy it generated.

Result: a rolled replica comes up but is never assigned a `role` (orphaned), and the roll never proceeds to the remaining pods.

## Fix

Add `control-plane: controller-manager` to the operator `pod.labels` so the operator-generated NetworkPolicy admits the operator. Additive label; does not affect leader election (keyed on pod name), service selectors, or topology constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)