### PR TITLE
feat(flux-system): add image-reflector self-repair CronJob

### DIFF
--- a/kubernetes/apps/flux-system/image-reflector-healer/app/cronjob.yaml
+++ b/kubernetes/apps/flux-system/image-reflector-healer/app/cronjob.yaml
@@ -1,0 +1,91 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/batch/cronjob_v1.json
+# Self-repair for the flux image-reflector-controller "no tags in database" bug.
+#
+# The reflector keeps its scanned-tag database in an ephemeral emptyDir at /data.
+# On any restart (which happens during routine Flux controller upgrades) the DB is
+# wiped, but the ImageRepository's `.status.lastScanResult` survives. On the next
+# scan the reflector sees "tags did not change" vs that cached result and SKIPS
+# rewriting the now-empty DB, so every ImagePolicy goes Ready=False /
+# DependencyNotReady ("no tags in database") and image automation silently stops.
+#
+# Deleting the ImageRepository clears `.status`; Flux recreates it from git, the
+# fresh object has no lastScanResult, so it does a full scan and repopulates the DB.
+# This job automates exactly that: detect stuck policies, delete their repository,
+# and nudge the owning Kustomization to recreate it immediately.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: image-reflector-healer
+spec:
+  schedule: "*/15 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: OnFailure
+          serviceAccountName: image-reflector-healer
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            seccompProfile:
+              type: RuntimeDefault
+          containers:
+            - name: healer
+              # renovate: datasource=docker depName=alpine/k8s
+              image: docker.io/alpine/k8s:1.35.6
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  echo "[healer] scanning ImagePolicies in flux-system..."
+                  stuck="$(
+                    kubectl get imagepolicy -n flux-system \
+                      -o jsonpath='{range .items[*]}{.spec.imageRepositoryRef.name}{"|"}{.status.conditions[?(@.type=="Ready")].status}{"|"}{.status.conditions[?(@.type=="Ready")].reason}{"\n"}{end}' \
+                    | awk -F'|' '$2 == "False" && $3 == "DependencyNotReady" { print $1 }' \
+                    | sort -u
+                  )"
+                  if [ -z "$stuck" ]; then
+                    echo "[healer] no stuck ImagePolicies; nothing to do."
+                    exit 0
+                  fi
+                  echo "$stuck" | while IFS= read -r repo; do
+                    [ -z "$repo" ] && continue
+                    ks="$(kubectl get imagerepository "$repo" -n flux-system \
+                      -o jsonpath='{.metadata.labels.kustomize\.toolkit\.fluxcd\.io/name}' 2>/dev/null || true)"
+                    ksns="$(kubectl get imagerepository "$repo" -n flux-system \
+                      -o jsonpath='{.metadata.labels.kustomize\.toolkit\.fluxcd\.io/namespace}' 2>/dev/null || true)"
+                    echo "[healer] healing ImageRepository '$repo' (owner ks: ${ksns:-?}/${ks:-?})"
+                    kubectl delete imagerepository "$repo" -n flux-system --ignore-not-found
+                    if [ -n "$ks" ] && [ -n "$ksns" ]; then
+                      kubectl annotate kustomization "$ks" -n "$ksns" \
+                        "reconcile.fluxcd.io/requestedAt=$(date -u +%FT%TZ)" --overwrite
+                    fi
+                  done
+                  echo "[healer] heal pass complete."
+              env:
+                - name: HOME
+                  value: /tmp
+              securityContext:
+                allowPrivilegeEscalation: false
+                readOnlyRootFilesystem: true
+                capabilities:
+                  drop: [ALL]
+              resources:
+                requests:
+                  cpu: "25m"
+                  memory: "64Mi"
+                limits:
+                  cpu: "200m"
+                  memory: "128Mi"
+              volumeMounts:
+                - name: tmp
+                  mountPath: /tmp
+          volumes:
+            - name: tmp
+              emptyDir: {}

--- a/kubernetes/apps/flux-system/image-reflector-healer/app/kustomization.yaml
+++ b/kubernetes/apps/flux-system/image-reflector-healer/app/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./rbac.yaml
+  - ./cronjob.yaml

--- a/kubernetes/apps/flux-system/image-reflector-healer/app/rbac.yaml
+++ b/kubernetes/apps/flux-system/image-reflector-healer/app/rbac.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: image-reflector-healer
+---
+# Namespaced Role: ImagePolicy/ImageRepository and the owning Kustomizations all
+# live in flux-system, so a Role (not ClusterRole) is sufficient — least privilege.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: image-reflector-healer
+rules:
+  # Detect stuck policies.
+  - apiGroups: ["image.toolkit.fluxcd.io"]
+    resources: ["imagepolicies"]
+    verbs: ["get", "list"]
+  # Force a fresh scan by deleting the ImageRepository; Flux recreates it from git.
+  - apiGroups: ["image.toolkit.fluxcd.io"]
+    resources: ["imagerepositories"]
+    verbs: ["get", "list", "delete"]
+  # Annotate the owning Kustomization to recreate the repository immediately
+  # instead of waiting for the next reconcile interval.
+  - apiGroups: ["kustomize.toolkit.fluxcd.io"]
+    resources: ["kustomizations"]
+    verbs: ["get", "list", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: image-reflector-healer
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: image-reflector-healer
+subjects:
+  - kind: ServiceAccount
+    name: image-reflector-healer
+    namespace: flux-system

--- a/kubernetes/apps/flux-system/image-reflector-healer/ks.yaml
+++ b/kubernetes/apps/flux-system/image-reflector-healer/ks.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app image-reflector-healer
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    # Needs the image-automation CRDs (ImagePolicy/ImageRepository) and the
+    # reflector itself, both delivered by the FluxInstance.
+    - name: flux-instance
+      namespace: flux-system
+  interval: 1h
+  path: ./kubernetes/apps/flux-system/image-reflector-healer/app
+  prune: true
+  retryInterval: 2m
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  targetNamespace: flux-system
+  timeout: 5m
+  wait: true

--- a/kubernetes/apps/flux-system/kustomization.yaml
+++ b/kubernetes/apps/flux-system/kustomization.yaml
@@ -13,3 +13,5 @@ resources:
   # these are for image automation (basically, flux-powered Renovate) for images hosted in gitea
   - ./bluevulpine-blog/ks.yaml
   - ./helium-archiver/ks.yaml
+  # self-repair for the reflector "no tags in database" bug (recurs on reflector restart)
+  - ./image-reflector-healer/ks.yaml


### PR DESCRIPTION
## Problem

The `image-reflector-controller` keeps its scanned-tag database in an **ephemeral emptyDir at `/data`**. On any restart (which happens during routine Flux controller upgrades) the DB is wiped, but the `ImageRepository`'s `.status.lastScanResult` survives. On the next scan the reflector compares the registry against that cached result, sees **"tags did not change"**, and **skips rewriting the now-empty DB**. Every `ImagePolicy` then goes `Ready=False / DependencyNotReady` ("no tags in database") and **image automation silently stops** (auto-promotion of `bluevulpine-blog` and `helium-archiver`).

Observed **twice**: a June 15 reflector restart, and again right after the flux-operator 0.52 bump (#1346).

## Why not persist `/data`?

The DB is **rebuildable** — a persistent volume would add a stateful dependency on a core Flux component *and* would persist a genuinely corrupt DB across restarts. Clearing-and-rescanning is strictly more robust.

## Fix

A CronJob (every 15m, `flux-system`) that:
1. Lists `ImagePolicies`; selects any `Ready=False / DependencyNotReady`.
2. Deletes the referenced `ImageRepository` (clears the stale `.status`).
3. Annotates the owning Kustomization (`reconcile.fluxcd.io/requestedAt`) so Flux recreates it immediately → fresh full scan → DB repopulated → policy resolves.

Idempotent (acts only when a policy is actually stuck), least-privilege namespaced `Role` (no ClusterRole), hardened pod (non-root, RO rootfs, drop ALL caps).

Validated: kubeconform clean; kustomize renders; the detection logic dry-run against the live cluster correctly identifies the two currently-stuck policies and resolves their owning Kustomizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)