### PR TITLE
fix(thanos): single store-gateway replica to avoid v0.41.0 /metrics 500 (TargetDown)

### DIFF
--- a/kubernetes/apps/observability/thanos/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/thanos/app/helmrelease.yaml
@@ -47,10 +47,11 @@ spec:
       value:
         type: s3
         config:
-          insecure: true  # Garage S3 API uses HTTP
+          insecure: true # Garage S3 API uses HTTP
     additionalEndpoints:
       - dnssrv+_grpc._tcp.kube-prometheus-stack-thanos-discovery.observability.svc.cluster.local
-    additionalReplicaLabels: ["__replica__"]
+    additionalReplicaLabels:
+      - "__replica__"
     serviceMonitor:
       enabled: true
     compact:
@@ -67,7 +68,8 @@ spec:
         size: 20Gi
     query:
       replicas: 2
-      extraArgs: ["--alert.query-url=https://thanos.${SECRET_DOMAIN}"]
+      extraArgs:
+        - "--alert.query-url=https://thanos.${SECRET_DOMAIN}"
     queryFrontend:
       enabled: true
       replicas: 2
@@ -77,7 +79,8 @@ spec:
             configMapKeyRef:
               name: &configMap thanos-cache-configmap
               key: cache.yaml
-      extraArgs: ["--query-range.response-cache-config=$(THANOS_CACHE_CONFIG)"]
+      extraArgs:
+        - "--query-range.response-cache-config=$(THANOS_CACHE_CONFIG)"
       ingress:
         enabled: false
       podAnnotations: &podAnnotations
@@ -85,7 +88,8 @@ spec:
     rule:
       enabled: true
       replicas: 2
-      extraArgs: ["--web.prefix-header=X-Forwarded-Prefix"]
+      extraArgs:
+        - "--web.prefix-header=X-Forwarded-Prefix"
       alertmanagersConfig:
         value: |-
           alertmanagers:
@@ -106,14 +110,26 @@ spec:
                     severity: critical
       persistence: *persistence
     storeGateway:
-      replicas: 2
+      # Single replica: Thanos v0.41.0 regression (thanos-io/thanos#8711) makes
+      # Query's /metrics return HTTP 500 when two store-gateways read the same
+      # bucket and advertise identical external labels — they collide on the
+      # thanos_store_nodes_grpc_connections series, failing the whole scrape and
+      # firing TargetDown. One store endpoint avoids the duplicate. Store-gateway
+      # is a stateless read layer over object storage (recent data is served by
+      # the HA sidecars), so dropping to one replica is acceptable here.
+      # Revert to replicas: 2 once #8711 is fixed in a stable release.
+      replicas: 1
       extraEnv: *extraEnv
-      extraArgs: ["--index-cache.config=$(THANOS_CACHE_CONFIG)"]
+      extraArgs:
+        - "--index-cache.config=$(THANOS_CACHE_CONFIG)"
       persistence: *persistence
       podAnnotations: *podAnnotations
       resources:
         requests:
           cpu: 10m
-          memory: 512Mi
-        limits:
+          # Bumped (512Mi -> 1Gi req, 1Gi -> 2Gi limit) for headroom now that a
+          # single replica serves all store-API/index-cache load; with only one
+          # replica an OOM would blank out all historical queries.
           memory: 1Gi
+        limits:
+          memory: 2Gi


### PR DESCRIPTION
## Problem

`TargetDown` firing: 100% of `thanos-query` targets in `observability` are down. The two `thanos-query` pods return **HTTP 500 on `/metrics`**:

```
collected metric "thanos_store_nodes_grpc_connections" {…, store_type="store"}
was collected before with the same name and label values
```

`client_golang` aborts the whole `/metrics` gather on a duplicate series, so Prometheus marks the scrape down. The pods themselves are healthy (readiness uses `/-/ready`), and PromQL serving is unaffected — only the query component's self-metrics are lost.

## Root cause

Confirmed **Thanos v0.41.0 regression — [thanos-io/thanos#8711](https://github.com/thanos-io/thanos/issues/8711)** (fine on v0.40.1). The two `thanos-store-gateway` replicas read the same bucket, so they advertise byte-identical external labels. The `thanos_store_nodes_grpc_connections` gauge is keyed on `(store_type, external_labels)`, so the two replicas emit an identical series → duplicate → 500. Verified via Prometheus targets API, the 500 body, and `/api/v1/stores` (only the `store` pair collides; `rule`/`sidecar` pairs have distinct labels).

No fix is available in a stable release yet (latest is v0.42.0-rc.1, no fix listed), and there is no config trick to keep two identical store-gateways on v0.41.0 without the 500.

## Change

- `storeGateway.replicas: 2 → 1` — removes the duplicate store endpoint. Store-gateway is a stateless read layer over object storage; recent data is served by the HA sidecars, so single replica is acceptable here.
- Memory `req 512Mi→1Gi`, `limit 1Gi→2Gi` — precautionary headroom now that one pod serves all store load. No prior OOM (RESTARTS=0, live usage ~270–400Mi), but a single-replica OOM would now blank all historical queries.

Revert to `replicas: 2` once #8711 ships in a stable release (tracked in the manifest comment).

## Validation

- `lefthook run pre-commit` — `format-yaml` + `gitleaks` pass.
- Root cause verified live against the cluster (targets API, `/metrics` body, `/api/v1/stores`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
