### PR TITLE
fix(thanos): bound store-gateway memory with lazy index-header reader

### DIFF
--- a/kubernetes/apps/observability/thanos/app/helmrelease.yaml
+++ b/kubernetes/apps/observability/thanos/app/helmrelease.yaml
@@ -120,16 +120,25 @@ spec:
       # Revert to replicas: 2 once #8711 is fixed in a stable release.
       replicas: 1
       extraEnv: *extraEnv
+      # Lazy index-header reader: by default store-gateway eagerly memory-maps
+      # every block's index-header at startup, which fills the cgroup limit with
+      # reclaimable page cache (working_set tracks the limit and trips
+      # ContainerMemoryCritical even though anonymous RSS is only ~220Mi). Lazy
+      # reader maps a block's index-header only when it is queried and releases
+      # it after the idle timeout, keeping memory bounded — important now that a
+      # single replica serves all store-API load.
       extraArgs:
         - "--index-cache.config=$(THANOS_CACHE_CONFIG)"
+        - --store.enable-index-header-lazy-reader
       persistence: *persistence
       podAnnotations: *podAnnotations
+      # Reverted to the original 512Mi/1Gi: the earlier 2Gi limit only gave the
+      # reclaimable index-header page cache more room to expand into and caused
+      # the OOM-imminent alert. With the lazy reader above, 1Gi is comfortable
+      # (these replicas ran at ~400Mi working_set under a 1Gi limit for months).
       resources:
         requests:
           cpu: 10m
-          # Bumped (512Mi -> 1Gi req, 1Gi -> 2Gi limit) for headroom now that a
-          # single replica serves all store-API/index-cache load; with only one
-          # replica an OOM would blank out all historical queries.
-          memory: 1Gi
+          memory: 512Mi
         limits:
-          memory: 2Gi
+          memory: 1Gi


### PR DESCRIPTION
## Problem

After scaling store-gateway to a single replica (#1416), `ContainerMemoryCritical` fired for `thanos-store-gateway-0` — working_set at ~99% of its limit, "OOM kill imminent".

## Root cause

Memory breakdown of the pod:

| metric | value |
| --- | --- |
| working_set (alert basis) | ~2019Mi |
| **anonymous RSS (real need)** | **~220Mi** |
| reclaimable page cache | ~1789Mi |

Store-gateway eagerly memory-maps **every** block's index-header at startup (664 blocks). Those mmap'd pages are reclaimable file cache, but they count toward `container_memory_working_set_bytes`. The earlier bump to a 2Gi limit (in #1416) just gave that cache more room to expand into, pushing working_set to ~99% and tripping the alert. Actual OOM risk was low — the kernel reclaims clean mmap'd pages before OOM-killing — but the alert is correct to flag it.

## Fix (root cause, not a bigger limit)

- **`--store.enable-index-header-lazy-reader`** — map a block's index-header only when it is queried, release it after the idle timeout. Keeps memory bounded under the consolidated single-replica load. (Flag verified present in the running v0.41.0 binary.)
- **Revert resources to 512Mi req / 1Gi limit** — the original known-good values; these replicas ran at ~400Mi working_set under a 1Gi limit for months. The 2Gi bump was counterproductive.

## Validation

- `lefthook run pre-commit` — `format-yaml` + `gitleaks` pass.
- Memory breakdown confirmed live via Prometheus (`container_memory_rss` vs `container_memory_cache` vs `..._working_set_bytes`).
- TargetDown from #1416 confirmed resolved: both `thanos-query` targets `up`, `store: 1` endpoint connected and serving (664 blocks synced).

## Expected after rollout

Store-gateway working_set drops well below 1Gi; `ContainerMemoryCritical` / `ContainerMemoryNearLimit` clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
