### PR TITLE
fix(tuppr): stop upgrade health gates from blocking forever (Syncthing + detached Longhorn volumes)

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -19,9 +19,14 @@ spec:
       kind: ReplicationSource
       expr: |-
         has(spec.syncthing) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
-    # Wait for Longhorn volumes to be healthy
+    # Require attached Longhorn volumes to be healthy, but ignore detached ones:
+    # a detached volume has robustness "unknown" (robustness is only meaningful
+    # while attached), so gating on state == "attached" would fail permanently —
+    # this cluster always has many idle/detached volumes (VolSync clones,
+    # scaled-down workloads). Only an attached-but-degraded volume (mid-rebuild)
+    # should actually block a node roll.
     - apiVersion: longhorn.io/v1beta2
       kind: Volume
       expr: |-
-        status.state == "attached" && status.robustness == "healthy"
+        status.state != "attached" || status.robustness == "healthy"
 

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -9,11 +9,16 @@ spec:
     # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
     version: v1.36.2
   healthChecks:
-    # Wait for VolSync backups to complete before upgrading
+    # Wait for VolSync backups to complete before upgrading, but exempt Syncthing
+    # movers: a Syncthing ReplicationSource maintains a continuous, live sync so it
+    # reports Synchronizing=True permanently and never flips to False. Without the
+    # has(spec.syncthing) short-circuit the gate can never pass and tuppr blocks
+    # every Talos/Kubernetes upgrade forever. Same property handled for the
+    # VolSyncVolumeOutOfSync alert in 0904f74d.
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource
       expr: |-
-        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+        has(spec.syncthing) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
     # Wait for Longhorn volumes to be healthy
     - apiVersion: longhorn.io/v1beta2
       kind: Volume

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -11,11 +11,16 @@ spec:
   policy:
     rebootMode: powercycle
   healthChecks:
-    # Wait for VolSync backups to complete before upgrading
+    # Wait for VolSync backups to complete before upgrading, but exempt Syncthing
+    # movers: a Syncthing ReplicationSource maintains a continuous, live sync so it
+    # reports Synchronizing=True permanently and never flips to False. Without the
+    # has(spec.syncthing) short-circuit the gate can never pass and tuppr blocks
+    # every Talos/Kubernetes upgrade forever. Same property handled for the
+    # VolSyncVolumeOutOfSync alert in 0904f74d.
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource
       expr: |-
-        status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+        has(spec.syncthing) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
     # Wait for Longhorn volumes to be healthy
     - apiVersion: longhorn.io/v1beta2
       kind: Volume

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -21,9 +21,14 @@ spec:
       kind: ReplicationSource
       expr: |-
         has(spec.syncthing) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
-    # Wait for Longhorn volumes to be healthy
+    # Require attached Longhorn volumes to be healthy, but ignore detached ones:
+    # a detached volume has robustness "unknown" (robustness is only meaningful
+    # while attached), so gating on state == "attached" would fail permanently —
+    # this cluster always has many idle/detached volumes (VolSync clones,
+    # scaled-down workloads). Only an attached-but-degraded volume (mid-rebuild)
+    # should actually block a node roll.
     - apiVersion: longhorn.io/v1beta2
       kind: Volume
       expr: |-
-        status.state == "attached" && status.robustness == "healthy"
+        status.state != "attached" || status.robustness == "healthy"
 


### PR DESCRIPTION
## Problem

tuppr's `TalosUpgrade`/`KubernetesUpgrade` health-check gates were **both** permanently unsatisfiable, so the cluster could never upgrade (stuck on Talos **v1.12.6** / k8s **v1.35.3**; targets v1.13.5 / v1.36.2). tuppr logs confirmed both:

```
Health check not satisfied ... index 0 ... kind: ReplicationSource
Health check not satisfied ... index 1 ... kind: Volume
Waiting for health checks ... error: health checks failed: exceeded maximum timeout of 10m0s
```

**Gate 0 — ReplicationSource (Syncthing):** required every VolSync source to report `Synchronizing=False`. Syncthing-mover sources (`games/valheim-syncthing`) sync continuously → `Synchronizing=True` forever → gate never passes.

**Gate 1 — Longhorn Volume (detached):** required `state=="attached" && robustness=="healthy"`. A detached volume has `robustness="unknown"`, so every idle/detached volume fails it. This cluster always has many (165 of 213 at time of writing; VolSync clones, scaled-down workloads) → gate never passes.

## Fix

- **ReplicationSource:** `has(spec.syncthing) || <existing sync check>` — Syncthing sources always pass; kopia/restic still gate on completion. Mirrors `0904f74d`.
- **Longhorn Volume:** `status.state != "attached" || status.robustness == "healthy"` — ignore detached volumes; only an **attached-but-degraded** volume (mid-rebuild) blocks a roll. Verified: all 48 attached volumes are currently healthy.

Applied to both `talosupgrade.yaml` and `kubernetesupgrade.yaml`.

## ⚠️ Impact

Merging removes the block and tuppr will begin the real rollout: **Talos v1.12.6→v1.13.5, then k8s v1.35.3→v1.36.2 — one node at a time, powercycle reboots + drains.** Confirmed with maintainer to merge and monitor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)