### PR TITLE
feat(flux): roll control plane to v2.9.0 via manifests artifact bump

### DIFF
--- a/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
+++ b/kubernetes/apps/flux-system/flux-instance/app/helmrelease.yaml
@@ -12,7 +12,14 @@ spec:
   values:
     instance:
       distribution:
-        artifact: oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:v0.32.0
+        # This artifact — not the flux-operator/flux-instance chart versions —
+        # determines the running Flux version. It was pinned at v0.32.0 (Flux
+        # v2.7.2) and had no renovate annotation, so operator/chart bumps never
+        # rolled the control plane. Annotate it so it tracks with the
+        # flux-operator group (the /flux-operator/ rule matches this depName).
+        # v0.53.0 bundles Flux v2.9.0; `version: 2.x` resolves to it.
+        # renovate: datasource=docker depName=ghcr.io/controlplaneio-fluxcd/flux-operator-manifests
+        artifact: oci://ghcr.io/controlplaneio-fluxcd/flux-operator-manifests:v0.53.0
         version: 2.x
       cluster:
         networkPolicy: false


### PR DESCRIPTION
## Why

The running Flux version is set by `spec.distribution.artifact` in the flux-instance HelmRelease — **not** by the `flux-operator`/`flux-instance` chart versions Renovate bumps. That artifact was pinned at `flux-operator-manifests:v0.32.0` (**Flux v2.7.2**) with no renovate annotation, so operator/chart bumps (including the recent 0.52→0.53 in #1424) upgraded the operator controller but left the control plane on **v2.7.2**.

## Change

- Bump the artifact `v0.32.0 → v0.53.0` (bundles **Flux v2.9.0**; matches the installed operator/instance charts). `version: 2.x` then resolves to v2.9.0.
- Add `# renovate: datasource=docker depName=…/flux-operator-manifests`. Because the depName contains `flux-operator`, the existing `/flux-operator/` group rule keeps the artifact in lockstep with the operator/instance charts from now on.
- Tag existence verified: `flux-operator-manifests:v0.53.0` → HTTP 200 on ghcr.

## Impact — real control-plane roll

This rolls source/kustomize/helm/notification/image controllers to **v2.9.0**. Merging auto-reconciles via webhook; I'll watch the FluxInstance apply v2.9.0 and each controller roll to Ready. On a bad fetch the FluxInstance just reports NotReady and the current control plane keeps running (recoverable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)