### PR TITLE
fix(lidarr): escape shell vars in init script for Flux v2.9.0 postBuild

### DIFF
--- a/kubernetes/apps/media/lidarr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/lidarr/app/helmrelease.yaml
@@ -33,15 +33,23 @@ spec:
             envFrom:
               - secretRef:
                   name: lidarr-secret
-            command: ["/bin/bash", "-c"]
+            command:
+              - "/bin/bash"
+              - "-c"
             args:
+              # $$ escapes each ${VAR}: these are runtime bash vars (from envFrom
+              # lidarr-secret / the container env), not Flux postBuild substitute
+              # vars. Flux kustomize-controller runs envsubst over the whole
+              # manifest; since Flux v2.9.0 an unmapped ${VAR} fails hard in strict
+              # mode (v2.7.2 silently left it literal). $$ makes Flux emit a literal
+              # ${VAR} for bash to expand at container runtime.
               - |
                 # Update Lidarr config to use hearring-aid as metadata source
-                export PGPASSWORD="${LIDARR__POSTGRES__PASSWORD}"
-                psql -h "${LIDARR__POSTGRES__HOST}" -U "${LIDARR__POSTGRES__USER}" -d "${LIDARR__POSTGRES__MAINDB}" -c \
-                  "INSERT INTO \"Config\" (\"Key\", \"Value\") VALUES ('metadatasource', '${LIDARR_METADATA_URL}')
+                export PGPASSWORD="$${LIDARR__POSTGRES__PASSWORD}"
+                psql -h "$${LIDARR__POSTGRES__HOST}" -U "$${LIDARR__POSTGRES__USER}" -d "$${LIDARR__POSTGRES__MAINDB}" -c \
+                  "INSERT INTO \"Config\" (\"Key\", \"Value\") VALUES ('metadatasource', '$${LIDARR_METADATA_URL}')
                    ON CONFLICT (\"Key\") DO UPDATE SET \"Value\" = EXCLUDED.\"Value\";"
-                echo "Metadata source configured to ${LIDARR_METADATA_URL}"
+                echo "Metadata source configured to $${LIDARR_METADATA_URL}"
         containers:
           app:
             image:


### PR DESCRIPTION
## Problem (surfaced by the Flux v2.9.0 roll)

lidarr's `02-init-metadata` init container runs a bash script referencing **runtime** env vars (`${LIDARR__POSTGRES__*}` from `lidarr-secret`, `${LIDARR_METADATA_URL}` from the container env). Flux's kustomize-controller runs envsubst over the whole manifest via `postBuild.substitute`.

- **Flux ≤ v2.7.2:** an unmapped `${VAR}` was left literal → bash expanded it at runtime → worked.
- **Flux v2.9.0:** fails hard in strict mode:
  ```
  post build failed ... variable not set (strict mode): "LIDARR__POSTGRES__PASSWORD"
  ```
  This wedged the `media/lidarr` Kustomization (and cascaded to `download/unpackerr`). The app kept running on its last good apply — only reconcile was blocked.

## Fix

Escape each shell `${VAR}` → `$${VAR}` (Flux's documented way to emit a literal `${VAR}` through postBuild). Legit Flux substitute vars in the same file (`${SECRET_DOMAIN}`, `${TIMEZONE}`, `${SECRET_NFS_*}`) are left single-`$` — they resolve from cluster settings. lidarr is the only app in the repo with this unescaped-shell-var-under-postBuild pattern.

Companion to the Flux v2.9.0 upgrade (#1439).

🤖 Generated with [Claude Code](https://claude.com/claude-code)