### PR TITLE
fix(tuppr): use status.syncthing (not spec) in health-check CEL

### DIFF
--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/kubernetesupgrade.yaml
@@ -12,13 +12,15 @@ spec:
     # Wait for VolSync backups to complete before upgrading, but exempt Syncthing
     # movers: a Syncthing ReplicationSource maintains a continuous, live sync so it
     # reports Synchronizing=True permanently and never flips to False. Without the
-    # has(spec.syncthing) short-circuit the gate can never pass and tuppr blocks
+    # has(status.syncthing) short-circuit the gate can never pass and tuppr blocks
     # every Talos/Kubernetes upgrade forever. Same property handled for the
-    # VolSyncVolumeOutOfSync alert in 0904f74d.
+    # VolSyncVolumeOutOfSync alert in 0904f74d. (tuppr's CEL env exposes only
+    # status, not spec — Syncthing sources are identified by status.syncthing;
+    # kopia/restic sources instead carry status.kopia/status.restic.)
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource
       expr: |-
-        has(spec.syncthing) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+        has(status.syncthing) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
     # Require attached Longhorn volumes to be healthy, but ignore detached ones:
     # a detached volume has robustness "unknown" (robustness is only meaningful
     # while attached), so gating on state == "attached" would fail permanently —

--- a/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
+++ b/kubernetes/apps/system-upgrade/tuppr/upgrades/talosupgrade.yaml
@@ -14,13 +14,15 @@ spec:
     # Wait for VolSync backups to complete before upgrading, but exempt Syncthing
     # movers: a Syncthing ReplicationSource maintains a continuous, live sync so it
     # reports Synchronizing=True permanently and never flips to False. Without the
-    # has(spec.syncthing) short-circuit the gate can never pass and tuppr blocks
+    # has(status.syncthing) short-circuit the gate can never pass and tuppr blocks
     # every Talos/Kubernetes upgrade forever. Same property handled for the
-    # VolSyncVolumeOutOfSync alert in 0904f74d.
+    # VolSyncVolumeOutOfSync alert in 0904f74d. (tuppr's CEL env exposes only
+    # status, not spec — Syncthing sources are identified by status.syncthing;
+    # kopia/restic sources instead carry status.kopia/status.restic.)
     - apiVersion: volsync.backube/v1alpha1
       kind: ReplicationSource
       expr: |-
-        has(spec.syncthing) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
+        has(status.syncthing) || status.conditions.filter(c, c.type == "Synchronizing").all(c, c.status == "False")
     # Require attached Longhorn volumes to be healthy, but ignore detached ones:
     # a detached volume has robustness "unknown" (robustness is only meaningful
     # while attached), so gating on state == "attached" would fail permanently —


### PR DESCRIPTION
Follow-up to #1437. tuppr rejected the Syncthing exemption at validation time:

```
invalid CEL expression 'has(spec.syncthing) || …': undeclared reference to 'spec'
```

tuppr's CEL environment exposes only the object's `status`, not `spec` (matching the existing exprs, which all reference `status.*`). Detect Syncthing sources via **`status.syncthing`** instead — a Syncthing `ReplicationSource` populates `status.syncthing` (device ID / peers), whereas kopia/restic sources carry `status.kopia` / `status.restic`. Verified against the live objects.

The Longhorn expr from #1437 (`status.state != "attached" || status.robustness == "healthy"`) uses only `status.*` and was already valid.

Once merged, both upgrade gates evaluate correctly and tuppr proceeds with the Talos → k8s rollout (still gated on kopia/restic backups being idle + attached volumes healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)