### PR TITLE
fix(tns-csi): add nouuid to xfs StorageClasses for snapshot/clone mounts

### DIFF
--- a/kubernetes/apps/kube-system/tns-csi/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/tns-csi/app/helmrelease.yaml
@@ -62,6 +62,14 @@ spec:
         reclaimPolicy: Delete
         volumeBindingMode: Immediate
         allowVolumeExpansion: true
+        # nouuid: a snapshot/clone of an XFS volume carries the SAME filesystem
+        # UUID as its source. XFS refuses to mount a volume whose UUID is already
+        # in use, so a VolSync backup clone fails to mount while the source is
+        # attached — surfacing as "bad superblock" (the fs is valid; only the
+        # mount is rejected). nouuid skips the UUID check. Required for xfs +
+        # snapshots/clones. See [[project_tns_csi_snapshot_bad_superblock]].
+        mountOptions:
+          - nouuid
 
       # ── NVMe-oF ──────────────────────────────────────────────────────────────
       # High-performance block storage over TCP. nvme_tcp kernel module is already
@@ -86,6 +94,10 @@ spec:
         reclaimPolicy: Delete
         volumeBindingMode: Immediate
         allowVolumeExpansion: true
+        # nouuid — required so VolSync snapshot/clone mounts don't fail with
+        # "bad superblock" on duplicate XFS UUID (see the iSCSI class above).
+        mountOptions:
+          - nouuid
 
       # ── SMB ──────────────────────────────────────────────────────────────────
       # Disabled until you create the credential Secret and enable SMB in TrueNAS.


### PR DESCRIPTION
## Problem

VolSync Snapshot backups of xfs tns-csi volumes wedge — the mover pod sits `ContainerCreating` indefinitely (25h+ for `games/valheim-local`) with:

```
MountVolume.MountDevice failed ... bad superblock on /dev/nvme2n1
```

Driver log shows the clone's filesystem is **valid** ("has existing filesystem, skipping format") — it fails only at *mount*.

## Root cause

An XFS snapshot/clone carries the **same filesystem UUID** as its source. XFS refuses to mount a volume whose UUID is already in use (the source is attached to the running workload), and that refusal surfaces as the generic `bad superblock`. The tns-csi NVMe-oF stage path doesn't pass `-o nouuid`. This blocks every VolSync Snapshot backup on xfs volumes — and in turn tuppr's `ReplicationSource` upgrade health gate (#1437/#1441).

## Fix

Add `mountOptions: [nouuid]` to the xfs classes (`tns-csi-nvmeof`, `tns-csi-iscsi`). `nouuid` skips the duplicate-UUID check; it's safe for source mounts too. **Not** switching to ext4 (would require recreating/migrating every volume) or btrfs (stricter about duplicate UUIDs — worse).

## Rollout / caveat

Applies to **newly provisioned** volumes. VolSync recreates its snapshot clone on every backup, so the next `valheim-local` sync picks it up — verifying the fix. Existing long-lived source PVs are unaffected (already mounted, single instance).

**If the driver doesn't honor PV mount flags** (`VolumeCapability.Mount.MountFlags`), this won't take effect and the fallback is a `nouuid` flag in the tns-csi driver's xfs stage path (first-party repo). I'll confirm which by watching the next clone mount after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)