### PR TITLE
fix(nextcloud): grant caps the Apache image needs (fix 34.x crashloop)

### DIFF
--- a/kubernetes/apps/productivity/nextcloud/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/nextcloud/app/helmrelease.yaml
@@ -104,9 +104,25 @@ spec:
                   timeoutSeconds: 10
                   failureThreshold: 120
             securityContext:
+              # The nextcloud Apache image starts as root and, in its entrypoint,
+              # rsync -a's the app tree into /var/www/html (preserving ownership →
+              # chown) then drops to www-data. Both need Linux capabilities that
+              # drop:[ALL] strips: without CHOWN the rsync fails "Operation not
+              # permitted" (exit 23), which the 34.x entrypoint treats as fatal →
+              # the Deployment never goes Ready → HelmRelease "stalled resources".
+              # Add back only the caps the image genuinely needs. (Older images
+              # tolerated the chown failures; 34.0.x does not — that's what broke.)
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: false
-              capabilities: {drop: ["ALL"]}
+              capabilities:
+                drop:
+                  - "ALL"
+                add:
+                  - "CHOWN"
+                  - "DAC_OVERRIDE"
+                  - "FOWNER"
+                  - "SETGID"
+                  - "SETUID"
             resources:
               requests:
                 cpu: 100m


### PR DESCRIPTION
## Root cause

nextcloud crashlooped for 2+ days; HelmRelease reported `stalled resources: [Deployment/productivity/nextcloud status: 'Failed']`. The crash log is a wall of:

```
rsync: [receiver] chown "/var/www/html/…" failed: Operation not permitted (1)
rsync error: some files/attrs were not transferred (code 23)
```

The nextcloud Apache image starts as **root** and its entrypoint `rsync -a`'s the app tree into `/var/www/html` (preserving ownership → `chown`), then drops to `www-data`. The container securityContext had `capabilities: {drop: ["ALL"]}`, which strips **CAP_CHOWN** (and SETUID/SETGID for the privilege drop). Being uid 0 isn't enough — chown needs the capability. So every chown returns `Operation not permitted`, rsync exits 23, and the **34.0.x** entrypoint treats that as fatal (older images tolerated it) → Deployment never Ready.

Tracks the `34.0.0`/`34.0.1` image bumps (#1355/#1426) that surfaced it; the `drop: ["ALL"]` itself was unchanged.

## Fix

Add back only the capabilities the image genuinely needs, still dropping everything else:

```yaml
capabilities:
  drop: ["ALL"]
  add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "SETGID", "SETUID"]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)