### PR TITLE
feat(postgres16): migrate storage to longhorn-1-replica-strict-local

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
@@ -10,8 +10,16 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:16.2-16
   primaryUpdateStrategy: unsupervised
   storage:
-    size: 20Gi
-    storageClass: openebs-hostpath
+    # Migrated off openebs-hostpath (node-local dir on the ephemeral /var partition,
+    # no quota — a 30Gi DB filled a node's ephemeral disk and triggered DiskPressure
+    # evictions). longhorn-1-replica-strict-local keeps each instance's data node-local
+    # on the dedicated SSDs with an enforced size; CNPG still replicates at the DB
+    # layer across the 3 instances. Migrate instances one at a time with
+    # `kubectl cnpg destroy postgres16 <n>` (rebuilds on the new class from the primary).
+    # 50Gi leaves headroom over the current ~30Gi (WAL + the 19Gi homeassistant DB
+    # pending recorder trimming); size can grow later but not shrink.
+    size: 50Gi
+    storageClass: longhorn-1-replica-strict-local
 
   superuserSecret:
     name: &secretName cloudnative-pg-secret
@@ -86,12 +94,12 @@ spec:
           secretAccessKey:
             name: *secretName
             key: s3-secret-access-key
-    # for initdb restore
-    # - name: old-cluster
-    #   connectionParameters:
-    #     host: postgres16-rw.default.svc.cluster.local
-    #     user: postgres
-    #     dbname: postgres
-    #   password:
-    #     name: *secretName
-    #     key: password
+            # for initdb restore
+            # - name: old-cluster
+            #   connectionParameters:
+            #     host: postgres16-rw.default.svc.cluster.local
+            #     user: postgres
+            #     dbname: postgres
+            #   password:
+            #     name: *secretName
+            #     key: password

--- a/kubernetes/apps/longhorn-system/longhorn/resources/kustomization.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/resources/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ../disks/brokkr03.yaml
   - ./snapshotclass.yaml
   - ./storageclass-1-replica.yaml
+  - ./storageclass-cnpg-strict-local.yaml
   - ./httproute.yaml
 

--- a/kubernetes/apps/longhorn-system/longhorn/resources/storageclass-cnpg-strict-local.yaml
+++ b/kubernetes/apps/longhorn-system/longhorn/resources/storageclass-cnpg-strict-local.yaml
@@ -1,0 +1,34 @@
+---
+# Single-replica Longhorn StorageClass with strict-local data locality, for
+# CloudNativePG. CNPG replicates at the database layer across its 3 instances, so
+# the storage layer needs NO replication of its own (numberOfReplicas: 1). We use
+# strict-local so the one Longhorn replica is pinned to the SAME node as the
+# attached Postgres pod — giving node-local read/write performance and keeping each
+# CNPG instance's data in its own node's failure domain (never a network hop to a
+# foreign node holding the replica). This replaces openebs-hostpath, which put
+# Postgres data on the ephemeral /var partition with no capacity enforcement — a
+# 30Gi DB there filled a node's ephemeral disk and evicted critical pods.
+# Deliberately NOT the default class and NOT strict-local for general workloads:
+# strict-local forces a replica rebuild whenever the pod moves nodes, which only
+# makes sense for a workload (like CNPG) that does its own replication.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: longhorn-1-replica-strict-local
+  labels:
+    app.kubernetes.io/name: longhorn
+    app.kubernetes.io/component: storage
+provisioner: driver.longhorn.io
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+parameters:
+  numberOfReplicas: "1"
+  dataLocality: strict-local
+  staleReplicaTimeout: "30"
+  fromBackup: ""
+  fsType: ext4
+  disableRevisionCounter: "true"
+  dataEngine: v1
+  backupTargetName: default
+  unmapMarkSnapChainRemoved: ignored


### PR DESCRIPTION
## Why

CNPG `postgres16` was on `openebs-hostpath` — a node-local dir on the Talos **ephemeral `/var`** partition with **no capacity enforcement**. The DB grew to ~30Gi (mostly a 19Gi `homeassistant` recorder DB), overran its 20Gi request, and filled brokkr03's 53Gi ephemeral partition to 85% → kubelet **DiskPressure** → evicted critical pods (OpenBao lost quorum → blank UI, fluent-bit DaemonSet stuck, cnpg replica evicted).

## Change

- New StorageClass **`longhorn-1-replica-strict-local`** (`numberOfReplicas: 1`, `dataLocality: strict-local`).
- Point `postgres16` storage at it, size **50Gi**.

CNPG replicates at the DB layer across its 3 instances, so the storage layer needs no replication of its own. `strict-local` pins each instance's single Longhorn replica to its **own** node → node-local performance, per-node failure domain (no network hop to a foreign replica), on the dedicated SSDs instead of ephemeral, with an enforced size.

## Rollout (manual, after merge)

The spec change is **inert** until instances are recreated. Migrate one at a time, replicas first, primary last:

```
kubectl cnpg destroy postgres16 <n>   # deletes instance pod+PVC; operator rebuilds on the new SC via pg_basebackup
```

Cluster stays HA (≥2/3) throughout; wait for each instance healthy + caught up before the next. Also relieves brokkr03's DiskPressure as the old openebs PVCs are freed.

Orthogonal follow-up: trim the 19Gi HA recorder DB (`purge_keep_days`, exclude noisy sensors) to shrink every replica.

🤖 Generated with [Claude Code](https://claude.com/claude-code)