### PR TITLE
fix(homebox): wire HBOX_AUTH_API_KEY_PEPPER from OpenBao

### DIFF
--- a/kubernetes/apps/productivity/homebox/app/externalsecret.yaml
+++ b/kubernetes/apps/productivity/homebox/app/externalsecret.yaml
@@ -29,6 +29,11 @@ spec:
         # OIDC credentials for Authentik integration
         HBOX_OIDC_CLIENT_ID: "{{ .Homebox__OAuthClientId }}"
         HBOX_OIDC_CLIENT_SECRET: "{{ .Homebox__OAuthClientSecret }}"
+        # API-key pepper — homebox ≥ the current build panics on startup without
+        # it ("auth.api_key_pepper must be set to at least 32 bytes"). Generated
+        # with `openssl rand -base64 48`; rotating it invalidates all issued API
+        # keys, so it is set once and left stable in OpenBao.
+        HBOX_AUTH_API_KEY_PEPPER: "{{ .Homebox__AuthApiKeyPepper }}"
   dataFrom:
     - extract:
         key: cloudnative-pg


### PR DESCRIPTION
The current homebox build panics on startup without an API-key pepper:
```
auth.api_key_pepper must be set to at least 32 bytes ... provide via HBOX_AUTH_API_KEY_PEPPER
```
Maps the new OpenBao field `Homebox__AuthApiKeyPepper` (generated `openssl rand -base64 48`, set once — rotating invalidates all API keys) into the secret. Resolves the long-standing homebox crashloop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)