### PR TITLE
fix(postgres16): revert storage to openebs-hostpath 20Gi (un-wedge)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
@@ -10,16 +10,15 @@ spec:
   imageName: ghcr.io/cloudnative-pg/postgresql:16.2-16
   primaryUpdateStrategy: unsupervised
   storage:
-    # Migrated off openebs-hostpath (node-local dir on the ephemeral /var partition,
-    # no quota — a 30Gi DB filled a node's ephemeral disk and triggered DiskPressure
-    # evictions). longhorn-1-replica-strict-local keeps each instance's data node-local
-    # on the dedicated SSDs with an enforced size; CNPG still replicates at the DB
-    # layer across the 3 instances. Migrate instances one at a time with
-    # `kubectl cnpg destroy postgres16 <n>` (rebuilds on the new class from the primary).
-    # 50Gi leaves headroom over the current ~30Gi (WAL + the 19Gi homeassistant DB
-    # pending recorder trimming); size can grow later but not shrink.
-    size: 50Gi
-    storageClass: longhorn-1-replica-strict-local
+    # Reverted to openebs-hostpath 20Gi to un-wedge the cluster: bumping size to
+    # 50Gi made CNPG try to resize the existing openebs-hostpath PVCs, which don't
+    # support expansion, erroring the reconcile and blocking instance recreation.
+    # Migration to longhorn-1-replica-strict-local will be redone with pvmigrate
+    # (direct data copy, keeps PVC names — avoids both the basebackup rebuild and
+    # the resize deadlock). The 28Gi actual data also can't fit a 20Gi enforced
+    # volume, so either pvmigrate to a larger dest or trim the HA recorder first.
+    size: 20Gi
+    storageClass: openebs-hostpath
 
   superuserSecret:
     name: &secretName cloudnative-pg-secret


### PR DESCRIPTION
Un-wedges the cluster. The prior change bumped `storage.size` 20Gi→50Gi with the storageClass; CNPG then tried to **resize the existing openebs-hostpath PVCs** (which don't support expansion) → reconcile errored every pass and never recreated the destroyed instance → stuck at 2/2.

Reverts storage to `openebs-hostpath` / `20Gi` so CNPG recreates the third instance and returns to 3/3. The `longhorn-1-replica-strict-local` SC stays for the retry, which will use **pvmigrate** (direct data copy, preserves PVC names) to avoid both the basebackup rebuild and the resize deadlock. Note: 28Gi actual data won't fit a 20Gi enforced Longhorn volume — retry needs a larger dest or an HA-recorder trim first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)