### PR TITLE
fix(postgres16): keep storage spec valid at longhorn/50Gi

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/cluster16.yaml
@@ -9,16 +9,14 @@ spec:
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql versioning=redhat
   imageName: ghcr.io/cloudnative-pg/postgresql:16.2-16
   primaryUpdateStrategy: unsupervised
+  # NOTE: size cannot be shrunk once raised (CNPG webhook rejects 50Gi→20Gi), so
+  # this stays 50Gi. The existing openebs-hostpath PVCs (20Gi, non-expandable)
+  # block CNPG's reconcile because it can't resize them to 50Gi — recovery is a
+  # PVC-level migration to longhorn done outside Flux (hibernate + pvmigrate/copy),
+  # after which this valid spec reconciles cleanly on the migrated 50Gi volumes.
   storage:
-    # Reverted to openebs-hostpath 20Gi to un-wedge the cluster: bumping size to
-    # 50Gi made CNPG try to resize the existing openebs-hostpath PVCs, which don't
-    # support expansion, erroring the reconcile and blocking instance recreation.
-    # Migration to longhorn-1-replica-strict-local will be redone with pvmigrate
-    # (direct data copy, keeps PVC names — avoids both the basebackup rebuild and
-    # the resize deadlock). The 28Gi actual data also can't fit a 20Gi enforced
-    # volume, so either pvmigrate to a larger dest or trim the HA recorder first.
-    size: 20Gi
-    storageClass: openebs-hostpath
+    size: 50Gi
+    storageClass: longhorn-1-replica-strict-local
 
   superuserSecret:
     name: &secretName cloudnative-pg-secret


### PR DESCRIPTION
The 20Gi revert was rejected by the CNPG webhook (can't shrink 50Gi→20Gi), leaving the `cloudnative-pg-cluster` Kustomization failing its dry-run and cascading to ~25 dependent apps. Set the spec to the valid target state (longhorn-1-replica-strict-local / 50Gi) so Flux applies cleanly. The operator-level wedge (existing 20Gi openebs PVCs can't resize to 50Gi) is recovered out-of-band via a PVC migration to 50Gi longhorn; once done, this spec reconciles → 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)