### PR TITLE
fix(postgres18): move serverName to Barman plugin param (v0.13.0 API)

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster18/cluster18.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster18/cluster18.yaml
@@ -43,14 +43,18 @@ spec:
   # Backups via the Barman Cloud Plugin — the in-tree spec.backup.barmanObjectStore
   # no longer works on 18.x (the image dropped the in-image barman-cloud tools). WAL
   # archiving + base backups stream to the postgres18-backup ObjectStore (see
-  # objectstore.yaml: same Garage S3 target as postgres16, serverName postgres18-v1).
-  # The plugin injects a sidecar into each instance; it's the sidecar-based successor
-  # to what postgres16 does in-image. scheduledbackup.yaml drives the base-backup cron.
+  # objectstore.yaml: same Garage S3 target as postgres16). The plugin injects a
+  # sidecar into each instance; it's the sidecar-based successor to what postgres16
+  # does in-image. scheduledbackup.yaml drives the base-backup cron.
+  # serverName (postgres18-v1) is set HERE, not on the ObjectStore: plugin v0.13.0
+  # requires the per-cluster serverName as a plugin parameter — it keeps postgres18's
+  # WAL/base backups from colliding with postgres16's in the shared bucket.
   plugins:
     - name: barman-cloud.cloudnative-pg.io
       isWALArchiver: true
       parameters:
         barmanObjectName: postgres18-backup
+        serverName: postgres18-v1
 
   # One-shot logical import of ALL databases + roles from the live postgres16.
   # Runs once, at initial creation only; read-only (pg_dump) on the source.

--- a/kubernetes/apps/database/cloudnative-pg/cluster18/objectstore.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster18/objectstore.yaml
@@ -1,9 +1,11 @@
 ---
 # Barman Cloud Plugin object-store config for postgres18 — the plugin equivalent of
 # postgres16's in-tree spec.backup.barmanObjectStore. Same Garage S3 destination and
-# credentials; distinct serverName (postgres18-v1) so its WAL/base backups never
-# collide with postgres16's in the shared bucket. Referenced from cluster18.yaml via
-# spec.plugins[].parameters.barmanObjectName.
+# credentials. The distinct serverName (postgres18-v1) that keeps its WAL/base backups
+# from colliding with postgres16's in the shared bucket is NOT set here: plugin v0.13.0
+# forbids spec.configuration.serverName on the ObjectStore and requires it as the
+# `serverName` plugin parameter on the Cluster instead (see cluster18.yaml
+# spec.plugins[].parameters). This ObjectStore is referenced by barmanObjectName.
 apiVersion: barmancloud.cnpg.io/v1
 kind: ObjectStore
 metadata:
@@ -13,7 +15,6 @@ spec:
   configuration:
     destinationPath: s3://cnpg/
     endpointURL: ${SECRET_GARAGE_S3_ENDPOINT}
-    serverName: postgres18-v1
     s3Credentials:
       accessKeyId:
         name: cloudnative-pg-secret


### PR DESCRIPTION
Follow-up hotfix to #1452, caught during the phase-1 resume of `cluster18`.

## Problem
Plugin **v0.13.0** forbids `spec.configuration.serverName` on the `ObjectStore` and requires the per-cluster `serverName` as a plugin **parameter** on the Cluster. The dry-run rejected it:

```
ObjectStore "postgres18-backup" is invalid: spec.configuration.serverName:
Forbidden: use the 'serverName' plugin parameter in the Cluster resource
```

That dry-run failure blocked the entire `cluster18` apply — `postgres18` Cluster + ObjectStore were never created.

## Fix
- Remove `serverName: postgres18-v1` from `objectstore.yaml` (`spec.configuration`).
- Add `serverName: postgres18-v1` to `cluster18.yaml` `spec.plugins[].parameters` (alongside `barmanObjectName`).

Still isolates postgres18's WAL/base backups from postgres16's in the shared Garage bucket. Verified with `kubectl apply --dry-run=server` — ObjectStore now validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)