### PR TITLE
feat(postgres18): cut over from postgres16 to postgres18

### DIFF
--- a/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/cluster/service.yaml
@@ -1,4 +1,12 @@
 ---
+# Canonical external postgres endpoint (postgres.${SECRET_DOMAIN} @ SVC_POSTGRES_ADDR).
+# External consumers reach postgres through this stable name/IP — notably Home
+# Assistant (out-of-cluster), whose recorder db_url points here. As of the 2026-07-07
+# cutover the selector routes to postgres18, so HA needs NO db_url change — the same
+# hostname/IP now backs pg18. postgres16 is kept (stopped) as rollback: reverting this
+# selector to postgres16 restores the old backend. (This Service still lives in the
+# postgres16 cluster dir; at pg16 decommission, move it into cluster18/ — see the
+# postgres18-lb note there.)
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,7 +16,7 @@ metadata:
     external-dns.alpha.kubernetes.io/hostname: "postgres.${SECRET_DOMAIN}"
     lbipam.cilium.io/ips: ${SVC_POSTGRES_ADDR}
   labels:
-      tailscale.com/proxy-class: "tun-access"
+    tailscale.com/proxy-class: "tun-access"
 spec:
   type: LoadBalancer
   ports:
@@ -17,5 +25,5 @@ spec:
       protocol: TCP
       targetPort: 5432
   selector:
-    cnpg.io/cluster: postgres16
+    cnpg.io/cluster: postgres18
     role: primary

--- a/kubernetes/apps/database/cloudnative-pg/ks.yaml
+++ b/kubernetes/apps/database/cloudnative-pg/ks.yaml
@@ -56,11 +56,8 @@ kind: Kustomization
 metadata:
   name: &app cloudnative-pg-cluster18
 spec:
-  # SUSPENDED on purpose: this stages the pg18 migration cluster without deploying
-  # it. Merging is inert. Activate the migration deliberately with
-  # `flux resume kustomization cloudnative-pg-cluster18` (or set suspend: false),
-  # which creates postgres18 and runs the one-shot import from live postgres16.
-  suspend: true
+  # ACTIVE as of the 2026-07-07 cutover: postgres18 is now the production cluster.
+  # (Was suspended while staged; the one-shot import from postgres16 has run.)
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
@@ -89,13 +86,10 @@ kind: Kustomization
 metadata:
   name: &app cnpg-barman-plugin
 spec:
-  # SUSPENDED with the rest of the pg18 migration — nothing deploys on merge.
-  # At phase 1, resume THIS first (installs the Barman Cloud Plugin: CRD + operator
-  # sidecar-injector in the database ns), wait for it Ready, THEN resume
-  # cloudnative-pg-cluster18 (which depends on it for the ObjectStore CRD).
-  # The plugin only ever affects clusters that opt in via spec.plugins — postgres16
-  # (in-image barman) is untouched.
-  suspend: true
+  # ACTIVE as of the 2026-07-07 cutover: installs the Barman Cloud Plugin (CRD +
+  # operator sidecar-injector in the database ns) that postgres18 uses for backups.
+  # cloudnative-pg-cluster18 dependsOn this. The plugin only affects clusters that
+  # opt in via spec.plugins — postgres16 (in-image barman) is untouched.
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app

--- a/kubernetes/apps/develop/drone/ks.yaml
+++ b/kubernetes/apps/develop/drone/ks.yaml
@@ -11,7 +11,7 @@ spec:
   dependsOn:
     - name: gitea
       namespace: develop
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/develop/gitea/ks.yaml
+++ b/kubernetes/apps/develop/gitea/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/develop/nexus/ks.yaml
+++ b/kubernetes/apps/develop/nexus/ks.yaml
@@ -11,7 +11,7 @@ spec:
   dependsOn:
     - name: external-secrets-openbao-store
       namespace: external-secrets
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
   path: ./kubernetes/apps/develop/nexus/app
   prune: true

--- a/kubernetes/apps/download/autobrr/ks.yaml
+++ b/kubernetes/apps/download/autobrr/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/home/frigate/ks.yaml
+++ b/kubernetes/apps/home/frigate/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/home/helium-archiver/ks.yaml
+++ b/kubernetes/apps/home/helium-archiver/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/identity/authentik/ks.yaml
+++ b/kubernetes/apps/identity/authentik/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: dragonfly-cluster
       namespace: database

--- a/kubernetes/apps/media/immich/ks.yaml
+++ b/kubernetes/apps/media/immich/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: dragonfly-cluster
       namespace: database

--- a/kubernetes/apps/media/lidarr/ks.yaml
+++ b/kubernetes/apps/media/lidarr/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/media/prowlarr/ks.yaml
+++ b/kubernetes/apps/media/prowlarr/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/media/radarr/ks.yaml
+++ b/kubernetes/apps/media/radarr/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/media/readarr-audiobooks/ks.yaml
+++ b/kubernetes/apps/media/readarr-audiobooks/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/media/readarr-ebooks/ks.yaml
+++ b/kubernetes/apps/media/readarr-ebooks/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/media/rreading-glasses/ks.yaml
+++ b/kubernetes/apps/media/rreading-glasses/ks.yaml
@@ -17,7 +17,7 @@ spec:
     namespace: flux-system
   targetNamespace: media
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
   wait: false
   postBuild:

--- a/kubernetes/apps/media/sonarr/ks.yaml
+++ b/kubernetes/apps/media/sonarr/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/observability/gatus/ks.yaml
+++ b/kubernetes/apps/observability/gatus/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/observability/grafana/ks.yaml
+++ b/kubernetes/apps/observability/grafana/ks.yaml
@@ -9,6 +9,8 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
+    - name: cloudnative-pg-cluster18
+      namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets
   path: ./kubernetes/apps/observability/grafana/app

--- a/kubernetes/apps/productivity/atuin/ks.yaml
+++ b/kubernetes/apps/productivity/atuin/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/productivity/homebox/ks.yaml
+++ b/kubernetes/apps/productivity/homebox/ks.yaml
@@ -11,7 +11,7 @@ spec:
   dependsOn:
     - name: external-secrets-openbao-store
       namespace: external-secrets
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
   path: ./kubernetes/apps/productivity/homebox/app
   prune: true

--- a/kubernetes/apps/productivity/joplin-server/ks.yaml
+++ b/kubernetes/apps/productivity/joplin-server/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/productivity/karakeep/ks.yaml
+++ b/kubernetes/apps/productivity/karakeep/ks.yaml
@@ -11,7 +11,7 @@ spec:
   dependsOn:
     - name: external-secrets-openbao-store
       namespace: external-secrets
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
   path: ./kubernetes/apps/productivity/karakeep/app
   prune: true

--- a/kubernetes/apps/productivity/mealie/ks.yaml
+++ b/kubernetes/apps/productivity/mealie/ks.yaml
@@ -11,7 +11,7 @@ spec:
   dependsOn:
     - name: external-secrets-openbao-store
       namespace: external-secrets
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
   path: ./kubernetes/apps/productivity/mealie/app
   prune: true

--- a/kubernetes/apps/productivity/n8n/ks.yaml
+++ b/kubernetes/apps/productivity/n8n/ks.yaml
@@ -9,7 +9,7 @@ spec:
     labels:
       app.kubernetes.io/name: *app
   dependsOn:
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
     - name: external-secrets-openbao-store
       namespace: external-secrets

--- a/kubernetes/apps/productivity/nextcloud/ks.yaml
+++ b/kubernetes/apps/productivity/nextcloud/ks.yaml
@@ -11,7 +11,7 @@ spec:
   dependsOn:
     - name: external-secrets-openbao-store
       namespace: external-secrets
-    - name: cloudnative-pg-cluster
+    - name: cloudnative-pg-cluster18
       namespace: database
   path: ./kubernetes/apps/productivity/nextcloud/app
   prune: true

--- a/kubernetes/components/common/cluster-config/cluster-settings.yaml
+++ b/kubernetes/components/common/cluster-config/cluster-settings.yaml
@@ -11,7 +11,8 @@ data:
   # instead of hardcoding the cluster name, so a major-version cluster swap
   # (e.g. postgres16 → postgres18) is a ONE-LINE cutover here rather than 25 edits.
   # (Distinct from SVC_POSTGRES_ADDR below, which is a static LB IP.)
-  POSTGRES_HOST: "postgres16-rw.database.svc.cluster.local"
+  # Cut over to postgres18 on 2026-07-07; postgres16 kept (stopped) as rollback.
+  POSTGRES_HOST: "postgres18-rw.database.svc.cluster.local"
   SVC_K8S_API_ADDR: 172.16.8.1
   SVC_NGINX_INTERNAL: 172.16.8.2
   SVC_NGINX_EXTERNAL: 172.16.8.3


### PR DESCRIPTION
Production cutover to postgres18 after a fresh, quiesced re-import (all 24 pg writers stopped + HA recorder disabled).

## Verified on the fresh import
- pg **18.2**, **43** DBs, **32** user roles, HA `states` **47,218,302** (exact vs pg16), pgvector **0.8.1**.
- **WAL archiving clean** on the wiped `postgres18-v1` (0 failures, `ContinuousArchiving=True`).

## Changes
- `cluster-settings`: `POSTGRES_HOST` → `postgres18-rw` (one-line in-cluster cutover).
- `cloudnative-pg/ks.yaml`: drop `suspend` on `cloudnative-pg-cluster18` + `cnpg-barman-plugin` (now permanent).
- `cluster/service.yaml`: `postgres-lb` selector `postgres16` → `postgres18` — same `postgres.${SECRET_DOMAIN}`/IP, so **external Home Assistant needs no `db_url` change**. Reverting = rollback.
- 23 app `ks.yaml`: `dependsOn` `cloudnative-pg-cluster` → `cloudnative-pg-cluster18` (also clears the stuck dependency cascade).
- `grafana/ks.yaml`: add the missing pg-cluster `dependsOn`.

postgres16 kept (stopped) as rollback; decommission is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)