### PR TITLE
fix(cross-seed): bump to v7 + migrate config for qBittorrent 5.x

### DIFF
--- a/kubernetes/apps/download/cross-seed/app/externalsecret.yaml
+++ b/kubernetes/apps/download/cross-seed/app/externalsecret.yaml
@@ -16,16 +16,17 @@ spec:
         config.js: |
           module.exports = {
             delay: 30,
-            qbittorrentUrl: "http://qbittorrent-app.download.svc.cluster.local:8080",
+            torrentClients: [
+              "qbittorrent:http://qbittorrent-app.download.svc.cluster.local:8080",
+            ],
             torznab: [
               "http://prowlarr.media.svc.cluster.local:9696/3/api?apikey={{ .Prowlarr__ApiKey }}",
             ],
             action: "inject",
-            includeEpisodes: true,
             includeSingleEpisodes: true,
             includeNonVideos: true,
             duplicateCategories: true,
-            matchMode: "safe",
+            matchMode: "strict",
             skipRecheck: true,
             outputDir: "/media/downloads/torrents/cross-seed",
             torrentDir: "/config/qBittorrent/BT_backup",

--- a/kubernetes/apps/download/cross-seed/app/helmrelease.yaml
+++ b/kubernetes/apps/download/cross-seed/app/helmrelease.yaml
@@ -20,8 +20,9 @@ spec:
             image:
               repository: ghcr.io/cross-seed/cross-seed
               # renovate: datasource=docker depName=ghcr.io/cross-seed/cross-seed
-              tag: 6.0.0-43
-            args: ["daemon"]
+              tag: 7.0.0-22
+            args:
+              - "daemon"
             env:
               TZ: "${TIMEZONE}"
               PORT: &port 2468


### PR DESCRIPTION
## Problem

`cross-seed` has been crashlooping (~400 restarts) with `qBittorrent login failed with code 204` since qBittorrent rolled to **5.2.2**.

qBittorrent 5.x returns **HTTP 204** (not `200`) on `/api/v2/auth/login` for clients matched by `AuthSubnetWhitelist` (our pod subnet `10.69.0.0/16` ∈ the whitelisted `10.0.0.0/8`). Pinned cross-seed **6.0.0-43** hard-checks `status !== 200` and throws. cross-seed **7.x** changed this to `!response.ok`, which accepts any 2xx — and the whitelisted 204 still sets the `QBT_SID` cookie, so the session works.

## Fix

- Bump image `6.0.0-43` → **`7.0.0-22`**.
- Migrate `config.js` to the v7 schema (verified against `shared/configSchema.ts` + `constants.ts`):
  - `qbittorrentUrl` → `torrentClients: ["qbittorrent:..."]` (renamed in v7)
  - drop `includeEpisodes` (removed in v7; `includeSingleEpisodes` covers single episodes)
  - `matchMode: "safe"` → `"strict"` (v7 enum is `strict`/`flexible`/`partial`; `strict` is required for `action: inject` without `linkDirs`)

## Verification

- `7.0.0-22` image confirmed present in ghcr.
- Traced the v7 login path against the live qBittorrent: empty user/pass → whitelisted `204` + `Set-Cookie: QBT_SID` → v7 `!response.ok` accepts it → `/app/version` resolves via whitelist. Login succeeds.
- `yamlfmt` + `gitleaks` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)