### PR TITLE
fix(scrypted): raise memory limit 2Gi → 8Gi for HKSV cameras

### DIFF
--- a/kubernetes/apps/home/scrypted/app/helmrelease.yaml
+++ b/kubernetes/apps/home/scrypted/app/helmrelease.yaml
@@ -80,9 +80,16 @@ spec:
             resources:
               requests:
                 cpu: 200m
-                memory: 512Mi
+                memory: 1Gi
+              # Each HKSV camera spawns its own ffmpeg (record + stream) and
+              # Scrypted forks plugins into separate node processes ("RpcPeer").
+              # At a 2Gi cap the container peaked ~1.7Gi and the cgroup OOM-killer
+              # reaped ffmpeg/plugin children (logs: "RpcPeer has been killed",
+              # "streaming session killed ... ffmpeg exited") without restarting
+              # PID 1 — so cameras silently failed to load in HomeKit. The brokkr
+              # nodes have ~47Gi free, so give it generous headroom.
               limits:
-                memory: 2Gi
+                memory: 8Gi
     defaultPodOptions:
       securityContext:
         runAsNonRoot: false


### PR DESCRIPTION
## Problem

A couple cameras wouldn't load completely in HomeKit. Scrypted logs showed `RpcPeer has been killed` and `streaming session killed … ffmpeg exited`, and the container **peaked ~1.7 Gi against its 2 Gi limit** (0 restarts — the cgroup OOM-killer reaps ffmpeg/plugin child processes, not PID 1, so it's invisible as an OOMKill).

## Fix

Each HKSV camera runs its own ffmpeg (record + stream) and Scrypted forks plugins into separate node processes, so memory scales with camera count. `brokkr03` is at 23% (~47 Gi free), so raise request `512Mi → 1Gi` and limit `2Gi → 8Gi`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDWRZD6Y9fffDznt18XcLj