### PR TITLE
chore: gitignore Claude Code scratch dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ talos/clusterconfig/*.yaml
 talos/clusterconfig/talosconfig
 **/talosconfig
 talos/*.iso
+
+# Claude Code scratch (session ledgers, briefs, worktrees) — never commit
+.superpowers/
+.claude/worktrees/


### PR DESCRIPTION
Ignore `.superpowers/` (session ledgers/briefs) and `.claude/worktrees/` (local git worktrees) so they stop showing up in `git status`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MDWRZD6Y9fffDznt18XcLj