### PR TITLE
fix: auto-clear finished kia-collector jobs via ttlSecondsAfterFinished

### DIFF
--- a/kubernetes/apps/home/kia-collector/app/cronjob.yaml
+++ b/kubernetes/apps/home/kia-collector/app/cronjob.yaml
@@ -1,3 +1,4 @@
+---
 # Cached-state poll every 10 min — uses server-side cached data, does not wake
 # the car (no 12V drain). ~145-290 Kia calls/day; well under EU-style caps and
 # the community-recommended USA interval. Freshness is bounded by how often the
@@ -14,6 +15,11 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 2
+      # Auto-delete finished jobs (success OR failure) + their pods after 30 min.
+      # At the 10-min cadence a one-off transient failure self-clears after ~3
+      # cycles (so KubeJobFailed auto-resolves), while a persistent failure keeps
+      # producing fresh <30-min-old failed jobs and correctly stays alerting.
+      ttlSecondsAfterFinished: 1800
       template:
         spec:
           restartPolicy: OnFailure
@@ -71,6 +77,10 @@ spec:
   jobTemplate:
     spec:
       backoffLimit: 1
+      # Auto-delete finished jobs (success OR failure) + their pods after 6h.
+      # A failed daily run self-clears (KubeJobFailed auto-resolves) well before
+      # the next 12:30 UTC run, instead of lingering until 5 failures pile up.
+      ttlSecondsAfterFinished: 21600
       template:
         spec:
           restartPolicy: OnFailure


### PR DESCRIPTION
## Problem
`KubeJobFailed` stays firing as long as a failed Job object exists. With `failedJobsHistoryLimit: 5`, a one-off transient failure lingers until 5 more failures accumulate, so the alert re-notifies indefinitely on Alertmanager's group interval.

2026-07-16 triage: two stale failed jobs (`kia-collector-cached-29734490` @ 07-14, `kia-collector-force-29735310` @ 07-15) kept `KubeJobFailed` firing while the collector was healthy (cached succeeding every 10 min; a manual `--from=cronjob` force run woke the car and wrote 4 points in ~20s → the force failure was transient). Cleared the stale jobs by hand.

## Fix
Add `ttlSecondsAfterFinished` to both jobTemplates so finished jobs + pods auto-delete and the alert auto-resolves:
- **cached**: `1800` (30 min → ~3 cycles at the 10-min cadence)
- **force**: `21600` (6 h → clears before the next 12:30 UTC run)

A *persistent* failure still keeps a fresh <TTL-old failed job present and correctly stays alerting. Validated with server-side dry-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)