### PR TITLE
ci(github-action): skip claude-code-review on renovate[bot] PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Claude review on Renovate's bot-authored PRs. They are routine,
+    # first-party dependency bumps that don't warrant an AI code review, and the
+    # sweep evaluates them deliberately instead. A job-level guard yields a clean
+    # "skipped" check rather than the red failure the action's non-human-actor
+    # prompt-injection guardrail would otherwise produce on every Renovate PR.
+    if: github.event.pull_request.user.login != 'renovate[bot]'
 
     runs-on: ubuntu-latest
     permissions:
@@ -36,11 +37,6 @@ jobs:
         uses: anthropics/claude-code-action@1298632ce7736903d02a1435002705aa2a594a6c # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # Renovate is this repo's trusted first-party update mechanism; allow its
-          # bot-authored PRs to be reviewed. Scoped to renovate[bot] only (never '*')
-          # so the action's non-human-actor prompt-injection guardrail still blocks
-          # every other bot.
-          allowed_bots: 'renovate[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

Reverses #1492. Instead of **reviewing** Renovate PRs (`allowed_bots: 'renovate[bot]'`), Claude Code Review now **skips** them via a job-level `if` guard, producing a clean neutral "skipped" check rather than a red failure.

## Why

Renovate PRs are routine, first-party dependency bumps evaluated deliberately by the renovate sweep — an AI code review on each adds noise. Three possible states for a bot PR:

- **Reviewed** — prior behavior (#1492), now undone.
- **Red failure** — what removing `allowed_bots` alone would give: the action's non-human-actor prompt-injection guardrail refuses to run on bot PRs and reports `claude-review` as failed.
- **Skipped** ✅ — a false `if` marks the check neutral/skipped, which branch protection treats as passing.

Human-authored PRs are unaffected.

## Change

- Removed `allowed_bots: 'renovate[bot]'`.
- Added `if: github.event.pull_request.user.login != 'renovate[bot]'` at the job level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)