### PR TITLE
fix(karakeep): rename meilisearch dumpless-upgrade flag to --upgrade-db (v1.51)

### DIFF
--- a/kubernetes/apps/productivity/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/karakeep/app/helmrelease.yaml
@@ -28,7 +28,10 @@ spec:
             image:
               repository: busybox
               tag: latest
-            command: ["sh", "-c", "chown 568:568 /run && chmod 755 /run"]
+            command:
+              - "sh"
+              - "-c"
+              - "chown 568:568 /run && chmod 755 /run"
             securityContext:
               runAsUser: 0
               runAsGroup: 0
@@ -101,7 +104,12 @@ spec:
             command:
               - /bin/meilisearch
             args:
-              - --experimental-dumpless-upgrade
+              # Meilisearch v1.51 stabilized dumpless upgrade and renamed the flag
+              # --experimental-dumpless-upgrade -> --upgrade-db (same behavior). The old
+              # flag is rejected as an unknown argument in v1.51+, crashlooping the sidecar.
+              # This flag lets Meilisearch migrate its on-disk index in place across a
+              # version bump instead of requiring a dump/import.
+              - --upgrade-db
             env:
               MEILI_ENV: production
               MEILI_NO_ANALYTICS: "true"


### PR DESCRIPTION
## What

Meilisearch **v1.51.0** (merged in #1507) stabilized the dumpless-upgrade feature and **renamed the CLI flag** `--experimental-dumpless-upgrade` → `--upgrade-db` (identical behavior), removing the old flag.

The karakeep meilisearch sidecar still passed the old flag, so v1.51 rejected it as an `unexpected argument` and the sidecar crashlooped (exitCode 2). The `app` and `chrome` containers stayed up, but full-text search was down.

## Why it's safe

The meilisearch process died at argument parsing, **before opening the index on disk**, so the v1.49 index is untouched. Keeping `--upgrade-db` lets v1.51 migrate it in place on first start (no dump/import needed).

## Follow-up

This unblocks #1507 from the Renovate sweep. Meilisearch also removed some unused experimental features in v1.51 — none are used here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)