### PR TITLE
feat(cloudflare-tunnel): retire HTTP/2 Pi connectors, scale QUIC to 3x amd64 for HA

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease-quic.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease-quic.yaml
@@ -23,8 +23,17 @@ spec:
   values:
     controllers:
       cloudflare-tunnel-quic:
-        replicas: 1
+        # 3 replicas, one per amd64 (brokkr) node, for tunnel HA (replaces the
+        # retired HTTP/2 connectors). Node/anti-affinity is set in
+        # defaultPodOptions below.
+        replicas: 3
         strategy: RollingUpdate
+        # hostNetwork + required one-per-node anti-affinity means a surge pod has
+        # no free node to land on, so it would hang Pending. Recreate in place
+        # instead: at most one connector down at a time, two still serving.
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
         annotations:
           reloader.stakater.com/auto: "true"
         containers:
@@ -38,7 +47,7 @@ spec:
               TUNNEL_CRED_FILE: /etc/cloudflared/creds/credentials.json
               TUNNEL_METRICS: 0.0.0.0:8080
               TUNNEL_TRANSPORT_PROTOCOL: quic
-              TUNNEL_POST_QUANTUM: true  # Post-quantum cryptography for QUIC
+              TUNNEL_POST_QUANTUM: true # Post-quantum cryptography for QUIC
               TUNNEL_ID:
                 valueFrom:
                   secretKeyRef:
@@ -61,7 +70,7 @@ spec:
                 spec:
                   httpGet:
                     path: /ready
-                    port: &port 8080  # Different port to avoid conflicts
+                    port: &port 8080 # Different port to avoid conflicts
                   initialDelaySeconds: 0
                   periodSeconds: 10
                   timeoutSeconds: 1
@@ -70,7 +79,7 @@ spec:
             securityContext:
               allowPrivilegeEscalation: false
               readOnlyRootFilesystem: true
-              capabilities: { drop: ["ALL"] }
+              capabilities: {drop: ["ALL"]}
             resources:
               requests:
                 cpu: 10m
@@ -79,7 +88,27 @@ spec:
     defaultPodOptions:
       # hostNetwork required: Cilium BPF masquerading breaks QUIC UDP connections
       hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet  # Required for cluster DNS resolution with hostNetwork
+      dnsPolicy: ClusterFirstWithHostNet # Required for cluster DNS resolution with hostNetwork
+      affinity:
+        # Keep the tunnel off the arm64 Raspberry Pis (the throughput bottleneck
+        # we are retiring) — only schedule on amd64 (brokkr) nodes.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+        # One connector per node: with hostNetwork every pod binds the metrics
+        # port on the host, so two on the same node would collide. Required (not
+        # preferred) so a co-scheduled pod stays Pending rather than crashlooping.
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: cloudflare-tunnel-quic
+              topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/kubernetes/apps/network/cloudflare-tunnel/app/kustomization.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/kustomization.yaml
@@ -7,7 +7,12 @@ resources:
   - ./ocirepository.yaml
   - ./dnsendpoint.yaml
   - ./externalsecret.yaml
-  - ./helmrelease.yaml
+  # HTTP/2 tunnel retired 2026-07-31: its 2 connectors were pinned to a
+  # Raspberry Pi (jormungandr4, arm64) and were a throughput bottleneck for all
+  # external traffic. The QUIC tunnel below runs on amd64 (brokkr) nodes and now
+  # serves everything. Re-enable this line if QUIC proves unreliable and the
+  # HTTP/2 failover connectors are needed again.
+  # - ./helmrelease.yaml
   - ./helmrelease-quic.yaml
 configMapGenerator:
   - name: cloudflare-tunnel-configmap


### PR DESCRIPTION
## Why

The HTTP/2 cloudflared tunnel ran **2 connectors pinned to a Raspberry Pi** (jormungandr4, arm64). Sharing one tunnel ID with the QUIC connector, Cloudflare spread external traffic across all three, so a large share was doing TLS + tunnel crypto on the Pi — the likely cause of the ~0.5 MB/s external throughput measured on 2026-07-20. The HTTP/2 HR was always meant to be retired once QUIC stabilized, but it still declared `replicas: 2` and was live.

## Changes

- **Retire HTTP/2 tunnel**: comment it out of the kustomization (Flux prunes it); file + note kept so it can be restored if QUIC misbehaves.
- **QUIC 1 → 3 replicas** for HA (replaces the lost failover): one per amd64 (brokkr) node via required `arch=amd64` node affinity + one-per-node pod anti-affinity (hostNetwork binds the host metrics port).
- **rollingUpdate maxSurge=0/maxUnavailable=1**: nodes are fully allocated, so a surge pod would hang Pending; recreate in place, 2 connectors stay serving.

## Verification plan (post-merge)

- Confirm `cloudflare-tunnel` (HTTP/2) is pruned and the 2 jormungandr4 pods are gone.
- Confirm 3 `cloudflare-tunnel-quic` pods Running, one per brokkr node.
- Re-measure external throughput with `curl -w` (now deterministic on amd64).

## Out of scope

Does **not** address Cloudflare's 100 MB proxied-upload cap (Immich `413`s) — that needs a non-Cloudflare path (Pangolin), planned separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)