### PR TITLE
fix(cloudflare-tunnel): make QUIC tunnel a DaemonSet to fix rollout deadlock

### DIFF
--- a/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease-quic.yaml
+++ b/kubernetes/apps/network/cloudflare-tunnel/app/helmrelease-quic.yaml
@@ -23,16 +23,18 @@ spec:
   values:
     controllers:
       cloudflare-tunnel-quic:
-        # 3 replicas, one per amd64 (brokkr) node, for tunnel HA (replaces the
-        # retired HTTP/2 connectors). Node/anti-affinity is set in
+        # DaemonSet, not Deployment: this is a hostNetwork, one-connector-per-node
+        # workload. On the amd64 (brokkr) nodes it yields 3 connectors for tunnel
+        # HA (replacing the retired HTTP/2 ones). A Deployment cannot roll here --
+        # 3 pods across exactly 3 nodes with one-per-node placement leaves no spare
+        # node to move into, so every upgrade deadlocks (a replacement pod hangs
+        # Pending on anti-affinity). A DaemonSet is inherently one-per-node and
+        # rolls a node at a time. Node selection (arch=amd64) is in
         # defaultPodOptions below.
-        replicas: 3
+        type: daemonset
         strategy: RollingUpdate
-        # hostNetwork + required one-per-node anti-affinity means a surge pod has
-        # no free node to land on, so it would hang Pending. Recreate in place
-        # instead: at most one connector down at a time, two still serving.
+        # Roll one node at a time so the other two connectors keep serving.
         rollingUpdate:
-          maxSurge: 0
           maxUnavailable: 1
         annotations:
           reloader.stakater.com/auto: "true"
@@ -91,7 +93,9 @@ spec:
       dnsPolicy: ClusterFirstWithHostNet # Required for cluster DNS resolution with hostNetwork
       affinity:
         # Keep the tunnel off the arm64 Raspberry Pis (the throughput bottleneck
-        # we are retiring) — only schedule on amd64 (brokkr) nodes.
+        # we are retiring) -- only schedule on amd64 (brokkr) nodes. The DaemonSet
+        # already guarantees one pod per node, so no pod anti-affinity is needed
+        # (which also avoids the hostNetwork metrics-port collision).
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -100,15 +104,6 @@ spec:
                     operator: In
                     values:
                       - amd64
-        # One connector per node: with hostNetwork every pod binds the metrics
-        # port on the host, so two on the same node would collide. Required (not
-        # preferred) so a co-scheduled pod stays Pending rather than crashlooping.
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: cloudflare-tunnel-quic
-              topologyKey: kubernetes.io/hostname
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000


### PR DESCRIPTION
## Problem

PR #1558 scaled the QUIC tunnel to a **3-replica Deployment** with required one-per-node anti-affinity. Result: rollout **deadlocked** — 3 pods across exactly 3 amd64 nodes leaves no spare node for a replacement pod, so it hangs `Pending` (`FailedScheduling: didn't match pod anti-affinity`) and Helm times out (`Deployment status: Failed` → paged).

## Fix

This is a `hostNetwork`, one-connector-per-node workload — a **DaemonSet** is the right primitive:
- Exactly one pod per amd64 (brokkr) node (3 connectors, same HA intent).
- Rolls one node at a time (`maxUnavailable: 1`) — two connectors always serving.
- **Cannot** deadlock the way the Deployment did on every future image bump.

Changes: `type: deployment → daemonset`; drop `replicas`/`maxSurge`; drop pod anti-affinity (DaemonSet is inherently one-per-node, also removes the hostNetwork metrics-port collision concern); keep `arch=amd64` node affinity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)