### PR TITLE
feat(network): Pangolin — publish pangolin.${SECRET_DOMAIN} DNS now; Newt connector staged

### DIFF
--- a/docs/runbooks/pangolin-vps-setup.md
+++ b/docs/runbooks/pangolin-vps-setup.md
@@ -1,0 +1,155 @@
+# Pangolin VPS setup (external ingress for Immich)
+
+Stand up a self-hosted [Pangolin](https://docs.pangolin.net) server on an
+external VPS and connect the cluster to it with a **Newt** connector, giving
+Immich (and later other services) a public path that is **not** subject to
+Cloudflare Tunnel's two hard limits:
+
+- **100 MB proxied-upload cap** — Immich mobile uploads of full-res photos/videos
+  `413` through cloudflared. Hard limit on CF Free/Pro, every connector/transport.
+- **~1.6 MB/s per-stream throughput** — measured 2026-07-31 (see below). Retiring
+  the Raspberry-Pi tunnel connectors lifted this from ~0.5 → ~1.6 MB/s, but ~1.6
+  MB/s is intrinsic to CF Tunnel: the cluster WAN itself does 258/135 Mbit
+  down/up, so the tunnel — not the link — is the ceiling.
+
+A direct Pangolin/WireGuard path is limited only by the cluster's ~135 Mbit
+upload and the VPS bandwidth (≈10× the CF tunnel) with **no upload cap**.
+
+> Scope: keep **Cloudflare** as the front door for most services (free WAF, DDoS
+> protection, IP hiding). Route **only** Immich (and other >100 MB / high-
+> throughput services) through Pangolin. This also limits how much traffic hits
+> the VPS's (often metered) egress.
+
+## Architecture
+
+```
+                          ┌───────────────── external VPS (public IP) ─────────────────┐
+  Immich users ──HTTPS──► │  Traefik (LE certs)  →  Gerbil (WireGuard server)          │
+                          │  Pangolin (dashboard/API)                                  │
+                          └───────────────▲──────────────────────────┬─────────────────┘
+                                          │ outbound WireGuard        │ (no inbound to home)
+                                          │ (Newt dials OUT)          ▼
+                          ┌───────────────┴──── cluster (this repo) ──────────────────┐
+                          │  Newt connector (pangolin-newt, network ns, amd64)         │
+                          │     └─ forwards to  external.network.svc.cluster.local:443 │
+                          │  Envoy `external` Gateway → existing HTTPRoutes → services │
+                          └────────────────────────────────────────────────────────────┘
+```
+
+Newt targets the **same internal origin cloudflared uses**
+(`external.network.svc.cluster.local:443`), so Envoy HTTPRoutes, cert-manager
+certs, and authentik are untouched. Pangolin only replaces the transport leg for
+the hostnames you move to it.
+
+The cluster side is GitOps-managed: `kubernetes/apps/network/pangolin-newt/`.
+The VPS side is **not** in this repo — it is the manual setup below.
+
+## 1. Provision the VPS
+
+- **Size:** 1 vCPU / 1–2 GB RAM is plenty (Pangolin is light). Pick a provider
+  with generous/unmetered egress — all Immich traffic transits it.
+- **OS:** Debian 12+ or Ubuntu 22.04+.
+- **Public IPv4**, SSH key-only login, unattended-upgrades enabled.
+- **Firewall (ufw/provider):** allow only
+  - `22/tcp` (SSH, ideally source-restricted)
+  - `80/tcp`, `443/tcp` (Traefik)
+  - `51820/udp` (Gerbil WireGuard)
+  - `21820/udp` (Newt connector traffic)
+
+## 2. DNS
+
+Point these at the VPS public IP (Cloudflare can stay as DNS provider, but set
+these records **DNS-only / grey-cloud** so they are not CF-proxied):
+
+- `pangolin.<domain>` — the dashboard.
+- The app hostname(s) you are moving, e.g. `photos.<domain>` (Immich).
+
+> **Split-horizon caveat:** internal clients resolve `<app>.<domain>` to the LAN
+> Envoy IP (`172.16.8.2`) and will keep using the fast internal path — they never
+> touch the VPS. Only off-LAN users go through Pangolin. (This is also why tunnel
+> throughput tests must force the public edge with `curl --resolve`.)
+
+## 3. Install the Pangolin stack
+
+On the VPS, install Docker + Compose, then run the official installer:
+
+```bash
+curl -fsSL https://get.docker.com | sh
+# Pangolin installer (interactive): asks for root domain + dashboard domain,
+# provisions pangolin + gerbil + traefik via docker-compose, gets LE certs.
+# See https://docs.pangolin.net/self-host/quick-install for the current command.
+```
+
+Provide your root domain (`<domain>`) and dashboard domain
+(`pangolin.<domain>`). Traefik obtains its own Let's Encrypt certs (independent
+of the cluster's cert-manager wildcard).
+
+## 4. Create Org, Site, and Resource
+
+In the Pangolin dashboard (`https://pangolin.<domain>`):
+
+1. **Organization** — create one.
+2. **Site** — create a site of type **Newt**. This mints the connector
+   credentials: **Newt ID**, **Newt Secret**, and the **endpoint** URL. Save
+   these for step 5. (Do **not** install Newt on the VPS — it runs in the
+   cluster.)
+3. **Resource** — add an HTTP resource for the app hostname (e.g.
+   `photos.<domain>`), attached to the Site above, with **target**:
+   - host: `external.network.svc.cluster.local`
+   - port: `443`, TLS to backend enabled
+   - Host header / SNI: preserve the original host so Envoy routes correctly.
+   - Leave Pangolin's own SSO **off** (authentik already fronts the app via
+     Envoy) — transport-only.
+
+## 5. Store the connector credentials in OpenBao
+
+Add a `pangolin` key with these fields (PascalCase double-underscore per repo
+convention — matches `kubernetes/apps/network/pangolin-newt/app/externalsecret.yaml`):
+
+| OpenBao field | Value |
+| --- | --- |
+| `Pangolin__Endpoint` | `https://pangolin.<domain>` |
+| `Pangolin__NewtId` | the Newt ID from step 4 |
+| `Pangolin__NewtSecret` | the Newt Secret from step 4 |
+
+```bash
+# via the OpenBao CLI (adjust to your auth/mount)
+bao kv put <mount>/pangolin \
+  Pangolin__Endpoint="https://pangolin.<domain>" \
+  Pangolin__NewtId="<newt-id>" \
+  Pangolin__NewtSecret="<newt-secret>"
+```
+
+## 6. Enable the cluster connector
+
+Merge the `feat/pangolin-newt-immich` PR (kept as a **draft** until steps 1–5 are
+done — before the `pangolin` OpenBao key exists, the ExternalSecret fails and
+Newt crashloops). On merge, Flux deploys `pangolin-newt` in the `network`
+namespace; Newt reads the creds, dials the VPS, and registers the Site.
+
+## 7. Verify
+
+```bash
+# connector is up and registered
+kubectl -n network logs deploy/pangolin-newt | grep -iE "connect|registered|tunnel"
+
+# from OFF-LAN (or force the edge), a >100 MB upload should now succeed and
+# throughput should track ~135 Mbit, not ~1.6 MB/s:
+curl -o /dev/null -s -w 'up=%{speed_upload}B/s http=%{http_code}\n' \
+  -F file=@big-video.mp4 https://photos.<domain>/...   # (Immich upload endpoint)
+```
+
+## Notes / future
+
+- **HA:** started as a single Newt replica; a pod restart drops the tunnel for a
+  few seconds. Newer Pangolin supports multiple connectors per Site — add a
+  second replica (with anti-affinity) if Immich uptime demands it.
+- **Rollback:** the hostname's DNS still has its CF-proxied record available;
+  flip DNS back to the Cloudflare path to revert instantly. cloudflared and Newt
+  target the same origin, so both can serve in parallel during migration.
+- **Expansion:** to move another service, add a Pangolin Resource + flip that
+  hostname's DNS — no cluster change needed (Newt already targets the shared
+  Envoy origin).
+
+Related: `docs/runbooks/flux-image-automation.md`, and the memory
+`project_cloudflare_tunnel_pi_retire_pangolin`.

--- a/kubernetes/apps/network/kustomization.yaml
+++ b/kubernetes/apps/network/kustomization.yaml
@@ -14,5 +14,6 @@ resources:
   - ./external-dns/ks.yaml
   - ./external-services/garage/ks.yaml
   - ./external-services/openspeedtest/ks.yaml
+  - ./pangolin-newt/ks.yaml
   - ./tailscale/ks.yaml
   - ./unifi-phantom-clients-cleanup/ks.yaml

--- a/kubernetes/apps/network/pangolin-newt/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/pangolin-newt/app/dnsendpoint.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: pangolin
+spec:
+  endpoints:
+    # Pangolin dashboard / entry point, pointing at the external VPS. Both records
+    # are DNS-only (cloudflare-proxied: false): the VPS must answer ACME/HTTP
+    # directly for Traefik's Let's Encrypt certs and serve connector traffic
+    # itself -- CF-proxying would re-impose the tunnel limits we are avoiding.
+    - dnsName: "pangolin.${SECRET_DOMAIN}"
+      recordType: A
+      targets:
+        - "134.209.70.159"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"
+    - dnsName: "pangolin.${SECRET_DOMAIN}"
+      recordType: AAAA
+      targets:
+        - "2604:a880:400:d1:0:4:c54f:1"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/network/pangolin-newt/app/externalsecret.yaml
+++ b/kubernetes/apps/network/pangolin-newt/app/externalsecret.yaml
@@ -1,0 +1,26 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1.json
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: &name pangolin-newt-secret
+spec:
+  secretStoreRef:
+    name: openbao
+    kind: ClusterSecretStore
+
+  target:
+    name: *name
+    template:
+      engineVersion: v2
+      data:
+        # Newt reads these three env vars. They are minted when a Site is created
+        # in the Pangolin dashboard on the VPS; store them under the OpenBao
+        # `pangolin` key. See docs/runbooks/pangolin-vps-setup.md.
+        PANGOLIN_ENDPOINT: "{{ .Pangolin__Endpoint }}" # https://pangolin.<domain>
+        NEWT_ID: "{{ .Pangolin__NewtId }}"
+        NEWT_SECRET: "{{ .Pangolin__NewtSecret }}"
+
+  dataFrom:
+    - extract:
+        key: pangolin

--- a/kubernetes/apps/network/pangolin-newt/app/helmrelease.yaml
+++ b/kubernetes/apps/network/pangolin-newt/app/helmrelease.yaml
@@ -1,0 +1,77 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app pangolin-newt
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: pangolin-newt
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 3
+      strategy: rollback
+  values:
+    controllers:
+      pangolin-newt:
+        annotations:
+          reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/fosrl/newt
+              # renovate: datasource=docker depName=docker.io/fosrl/newt
+              tag: 1.15.0
+            # Newt is the tunnel *client*: it dials out to the Pangolin server
+            # (PANGOLIN_ENDPOINT over 443 + Gerbil WireGuard over UDP) and, once
+            # registered, forwards traffic to the target configured in the
+            # Pangolin dashboard for this Site -- point that at the same internal
+            # origin cloudflared uses (external.network.svc.cluster.local:443) so
+            # the existing Envoy HTTPRoutes/certs/authentik are unchanged. Nothing
+            # about the target lives here; only the connector credentials do.
+            envFrom:
+              - secretRef:
+                  name: pangolin-newt-secret
+            securityContext:
+              # Newt uses userspace WireGuard (netstack), so it needs no NET_ADMIN,
+              # no /dev/net/tun, and no privileged ports -- fully locked down.
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities: {drop: ["ALL"]}
+            resources:
+              requests:
+                cpu: 10m
+                memory: 32Mi
+              limits:
+                memory: 128Mi
+    defaultPodOptions:
+      affinity:
+        # Newt sits in the Immich data path (it forwards the tunneled bytes to
+        # the origin), so keep it on the amd64 (brokkr) nodes, off the arm64 Pis.
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: kubernetes.io/arch
+                    operator: In
+                    values:
+                      - amd64
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+    # Outbound-only client: no Service, no ingress ports.
+    persistence:
+      # readOnlyRootFilesystem needs a writable /tmp for any scratch state.
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp

--- a/kubernetes/apps/network/pangolin-newt/app/kustomization.yaml
+++ b/kubernetes/apps/network/pangolin-newt/app/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+components:
+  - ../../../../components/externalsecret-refresh
+resources:
+  - ./ocirepository.yaml
+  - ./externalsecret.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/network/pangolin-newt/app/kustomization.yaml
+++ b/kubernetes/apps/network/pangolin-newt/app/kustomization.yaml
@@ -4,6 +4,13 @@ kind: Kustomization
 components:
   - ../../../../components/externalsecret-refresh
 resources:
-  - ./ocirepository.yaml
-  - ./externalsecret.yaml
-  - ./helmrelease.yaml
+  # DNS for the Pangolin dashboard/entry on the VPS -- published now so the VPS
+  # can obtain LE certs and register connectors during setup.
+  - ./dnsendpoint.yaml
+  # --- Newt connector (Immich data path): enable only AFTER the Pangolin VPS
+  # Site is created and the OpenBao `pangolin` key is populated
+  # (Pangolin__Endpoint / __NewtId / __NewtSecret). Until then the ExternalSecret
+  # fails and Newt crashloops. See docs/runbooks/pangolin-vps-setup.md.
+  # - ./ocirepository.yaml
+  # - ./externalsecret.yaml
+  # - ./helmrelease.yaml

--- a/kubernetes/apps/network/pangolin-newt/app/ocirepository.yaml
+++ b/kubernetes/apps/network/pangolin-newt/app/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: pangolin-newt
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 5.0.1
+  url: oci://ghcr.io/bjw-s-labs/helm/app-template

--- a/kubernetes/apps/network/pangolin-newt/ks.yaml
+++ b/kubernetes/apps/network/pangolin-newt/ks.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app pangolin-newt
+spec:
+  commonMetadata:
+    labels:
+      app.kubernetes.io/name: *app
+  dependsOn:
+    # Needs the OpenBao ClusterSecretStore for the Newt connector credentials.
+    # The `pangolin` OpenBao key (Pangolin__Endpoint / __NewtId / __NewtSecret)
+    # must exist first -- it is created from a Site on the external Pangolin VPS.
+    # See docs/runbooks/pangolin-vps-setup.md.
+    - name: external-secrets-openbao-store
+      namespace: external-secrets
+  path: ./kubernetes/apps/network/pangolin-newt/app
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: home-kubernetes
+    namespace: flux-system
+  targetNamespace: network
+  wait: false
+  interval: 30m
+  retryInterval: 1m
+  timeout: 5m
+  postBuild:
+    substitute:
+      APP: *app
+      NS: network


### PR DESCRIPTION
Ships in two stages so DNS can go live during VPS bring-up while the connector waits.

## Live on merge
- **`pangolin.<domain>` DNS → the VPS**: `A 134.209.70.159`, `AAAA 2604:a880:400:d1:0:4:c54f:1`, **DNS-only** (`cloudflare-proxied: false`) so the VPS answers ACME/HTTP directly for Traefik's Let's Encrypt certs and serves connector traffic itself (CF-proxying would re-impose the tunnel limits we're avoiding).

## Staged (commented out until VPS ready)
- **Newt connector** (`ocirepository`/`externalsecret`/`helmrelease`) — enable by uncommenting in `app/kustomization.yaml` **after** the Pangolin VPS Site exists and the OpenBao `pangolin` key is populated (`Pangolin__Endpoint`/`__NewtId`/`__NewtSecret`). Before then the ExternalSecret fails and Newt crashloops.

## Why
CF Tunnel is intrinsically ~1.6 MB/s/stream (measured in-cluster 2026-07-31: cluster WAN 258/135 Mbit, tunnel ~1.6 MB/s) **and** caps uploads at 100 MB — both block Immich. Transport-only Pangolin (Newt → same `external.network.svc:443` origin, HTTPRoutes unchanged) gives Immich an uncapped ~135 Mbit path. Runbook: `docs/runbooks/pangolin-vps-setup.md`.

## Enable-the-connector checklist
- [ ] VPS + Pangolin stack up (runbook §1–3)
- [ ] Org + Newt Site + Immich Resource → `external.network.svc:443` (§4)
- [ ] OpenBao `pangolin` key populated (§5)
- [ ] Uncomment the 3 connector lines in `app/kustomization.yaml`; verify `kubectl -n network logs deploy/pangolin-newt` registers (§6–7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)