### PR TITLE
fix(network): drop pangolin AAAA until VPS serves IPv6 (unblocks LE cert)

### DIFF
--- a/kubernetes/apps/network/pangolin-newt/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/pangolin-newt/app/dnsendpoint.yaml
@@ -5,10 +5,10 @@ metadata:
   name: pangolin
 spec:
   endpoints:
-    # Pangolin dashboard / entry point, pointing at the external VPS. Both records
-    # are DNS-only (cloudflare-proxied: false): the VPS must answer ACME/HTTP
-    # directly for Traefik's Let's Encrypt certs and serve connector traffic
-    # itself -- CF-proxying would re-impose the tunnel limits we are avoiding.
+    # Pangolin dashboard / entry point, pointing at the external VPS. DNS-only
+    # (cloudflare-proxied: false): the VPS must answer ACME/HTTP directly for
+    # Traefik's Let's Encrypt certs and serve connector traffic itself --
+    # CF-proxying would re-impose the tunnel limits we are avoiding.
     - dnsName: "pangolin.${SECRET_DOMAIN}"
       recordType: A
       targets:
@@ -16,10 +16,8 @@ spec:
       providerSpecific:
         - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
           value: "false"
-    - dnsName: "pangolin.${SECRET_DOMAIN}"
-      recordType: AAAA
-      targets:
-        - "2604:a880:400:d1:0:4:c54f:1"
-      providerSpecific:
-        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
-          value: "false"
+          # AAAA (2604:a880:400:d1:0:4:c54f:1) intentionally omitted for now: the VPS
+          # is not serving on IPv6 (ports 80/443 refuse over v6), and Let's Encrypt
+          # validates the AAAA *first* when present, so publishing it makes Traefik's
+          # cert issuance fail and fall back to a self-signed cert. Re-add only after
+          # the VPS has working IPv6 (DO netplan + Traefik listening on [::]).


### PR DESCRIPTION
The VPS refuses IPv6 :80/:443 (IPv4-only). LE validates AAAA **first** when present, so the AAAA I added made Traefik's ACME fail → self-signed cert → HSTS block on the dashboard. Removing the AAAA lets LE issue over IPv4. Re-add once the VPS has working IPv6 (DO netplan + Traefik on `[::]`). external-dns (policy=sync) will delete the AAAA from Cloudflare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)