### PR TITLE
feat(immich): route photos through Pangolin via new external-pangolin gateway

### DIFF
--- a/kubernetes/apps/media/immich/app/dnsendpoint.yaml
+++ b/kubernetes/apps/media/immich/app/dnsendpoint.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: immich
+spec:
+  endpoints:
+    # Public record for Immich, pointing at the Pangolin VPS entry host instead
+    # of the Cloudflare tunnel. Read only by external-dns-cloudflare (the unifi
+    # instance has no `crd` source), so the LAN A record published from the
+    # `internal` Gateway is untouched -- split horizon preserved.
+    #
+    # DNS-only (cloudflare-proxied: false) is mandatory here, not cosmetic:
+    # orange-clouding this record would put CF back in the path and restore the
+    # 100MB upload cap and per-stream throttle this whole setup exists to avoid.
+    - dnsName: "photos.${SECRET_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "pangolin.${SECRET_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -159,7 +159,14 @@ spec:
           - name: internal
             namespace: network
             sectionName: https
-          - name: external
+          # Public traffic arrives via the Pangolin VPS -> Newt connector, NOT the
+          # Cloudflare tunnel: CF caps proxied uploads at 100MB (Immich 413s on
+          # full-res video) and throttles to ~1.6MB/s per stream. Attaching to
+          # `external-pangolin` instead of `external` is also what keeps split
+          # horizon working -- external-dns derives records per-gateway, so the
+          # public record comes from ./dnsendpoint.yaml while `internal` above
+          # still publishes the LAN A record for on-network clients.
+          - name: external-pangolin
             namespace: network
             sectionName: https
         hostnames:

--- a/kubernetes/apps/media/immich/app/kustomization.yaml
+++ b/kubernetes/apps/media/immich/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./nfs.yaml
+  - ./dnsendpoint.yaml
 components:
   - ../../../../components/externalsecret-refresh
   # volsync removed - using NFS with NAS-level backups

--- a/kubernetes/apps/network/envoy-gateway/resources/envoy.yaml
+++ b/kubernetes/apps/network/envoy-gateway/resources/envoy.yaml
@@ -32,6 +32,41 @@ spec:
         compression:
           type: Gzip
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/envoyproxy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: envoy-proxy-pangolin
+  namespace: network
+spec:
+  logging:
+    level:
+      default: info
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyDeployment:
+        replicas: 2
+        container:
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 1000m
+              memory: 512Mi
+      envoyService:
+        # ClusterIP, not LoadBalancer: this gateway is only ever reached from
+        # inside the cluster by the Newt connector, so it needs no LAN IP.
+        type: ClusterIP
+  shutdown:
+    drainTimeout: 60s
+  telemetry:
+    metrics:
+      prometheus:
+        compression:
+          type: Gzip
+---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/gatewayclass_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/kubernetes/apps/network/envoy-gateway/resources/gateways.yaml
+++ b/kubernetes/apps/network/envoy-gateway/resources/gateways.yaml
@@ -71,6 +71,45 @@ spec:
         namespaces:
           from: All
 ---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/gateway_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: external-pangolin
+  namespace: network
+  annotations:
+    # Belt-and-braces: neither external-dns instance watches this gateway
+    # (cloudflare is scoped --gateway-name=external, unifi --gateway-name=internal),
+    # and public DNS for Pangolin-served hosts comes from DNSEndpoint CRs instead.
+    external-dns.alpha.kubernetes.io/controller: none
+spec:
+  gatewayClassName: envoy
+  # Third ingress door, alongside `external` (Cloudflare tunnel) and `internal`
+  # (LAN). Traffic arrives from the Pangolin VPS via the in-cluster Newt
+  # connector, bypassing Cloudflare's 100MB upload cap and per-stream throughput
+  # limit. Keeping it as its own Gateway is what preserves split-horizon DNS:
+  # external-dns derives records per-gateway, so a host served here gets its
+  # public record from a DNSEndpoint while `internal` still publishes the LAN
+  # A record. ClusterIP-only -- reached solely by Newt inside the cluster.
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: envoy-proxy-pangolin
+  listeners:
+    # HTTPS only: Newt forwards to :443; there is no plaintext hop to redirect.
+    - name: https
+      protocol: HTTPS
+      port: 443
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: "${SECRET_DOMAIN/./-}-production-tls"
+            namespace: kube-system
+      allowedRoutes:
+        namespaces:
+          from: All
+---
 # yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute


### PR DESCRIPTION
Moves Immich's public path off the Cloudflare tunnel onto the Pangolin VPS.

## Why
CF caps proxied uploads at **100 MB** (Immich `413`s on full-res video) and throttles to **~1.6 MB/s per stream** — measured in-cluster 2026-07-31: WAN is **258/135 Mbit**, so the *tunnel* is the ceiling, not the link. With external Immich users now required, both limits bite.

## Why a third gateway (not reusing `external`)
external-dns derives records **per-gateway**, and that's exactly what preserves split horizon:

| Instance | sources | scope |
|---|---|---|
| `external-dns-cloudflare` | `crd`, `gateway-httproute` | `--gateway-name=external` |
| `external-dns-unifi` | `service`, `gateway-httproute` | `--gateway-name=internal` |

A route-level `target:`/`controller: none` annotation is read by **both** instances, so it would drag the LAN record along too. Attaching to a separate gateway is the only per-door lever.

- **`external-pangolin` Gateway** + dedicated `envoy-proxy-pangolin` EnvoyProxy — **ClusterIP** (no LAN IP; only Newt reaches it), HTTPS-only.
- **Immich HTTPRoute**: `external` → `external-pangolin`, **keeps `internal`** so LAN clients still hit `172.16.8.2` and never leave the network.
- **DNSEndpoint**: `photos` → CNAME `pangolin.<domain>`, **DNS-only**. Only the cloudflare instance reads `crd`, so the internal A record is untouched. `cloudflare-proxied` must stay `false` — orange-clouding would restore the very limits we're escaping.

Transport-only: Envoy still routes; certs/authentik/HTTPRoutes otherwise unchanged.

## Follow-up (manual, after merge)
Newt's target must change from `10.96.182.111:443` (old `external` svc) to **`external-pangolin.network.svc.cluster.local:443`** in the Pangolin dashboard (hostname targets are valid).

## Rollback
Restore the `external` parentRef and drop the DNSEndpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)