### PR TITLE
feat(pangolin): migrate sso, requests, karakeep, mealie, couchdb, openspeedtest + pangolin echo probe

### DIFF
--- a/kubernetes/apps/database/couchdb/app/dnsendpoint.yaml
+++ b/kubernetes/apps/database/couchdb/app/dnsendpoint.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: couchdb
+spec:
+  endpoints:
+    # Public record points at the Pangolin VPS entry host instead of the
+    # Cloudflare tunnel. Only external-dns-cloudflare reads `crd` sources, so the
+    # LAN A record published from the `internal` Gateway is untouched and split
+    # horizon still sends on-network clients straight to Envoy.
+    #
+    # DNS-only (cloudflare-proxied: false) is required, not cosmetic: orange
+    # clouding would put CF back in the path and restore the 100MB upload cap and
+    # per-stream throttle this migration exists to avoid.
+    - dnsName: "couchdb.${SECRET_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "pangolin.${SECRET_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/database/couchdb/app/httproute.yaml
+++ b/kubernetes/apps/database/couchdb/app/httproute.yaml
@@ -16,10 +16,11 @@ metadata:
     gethomepage.dev/icon: "couchdb.png"
     gethomepage.dev/description: "Document Database"
 spec:
-  hostnames: ["couchdb.${SECRET_DOMAIN}"]
+  hostnames:
+    - "couchdb.${SECRET_DOMAIN}"
   parentRefs:
     # External gateway - accessible via Cloudflare tunnel for remote Obsidian clients
-    - name: external
+    - name: external-pangolin
       namespace: network
       sectionName: https
     # Internal gateway - direct internal access for local Obsidian clients

--- a/kubernetes/apps/database/couchdb/app/kustomization.yaml
+++ b/kubernetes/apps/database/couchdb/app/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./httproute.yaml
   - ./externalsecret.yaml
   - ./configmap.yaml
+  - ./dnsendpoint.yaml
 components:
   - ../../../../components/volsync
   - ../../../../components/externalsecret-refresh

--- a/kubernetes/apps/identity/authentik/app/dnsendpoint.yaml
+++ b/kubernetes/apps/identity/authentik/app/dnsendpoint.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: authentik
+spec:
+  endpoints:
+    # Public record points at the Pangolin VPS entry host instead of the
+    # Cloudflare tunnel. Only external-dns-cloudflare reads `crd` sources, so the
+    # LAN A record published from the `internal` Gateway is untouched and split
+    # horizon still sends on-network clients straight to Envoy.
+    #
+    # DNS-only (cloudflare-proxied: false) is required, not cosmetic: orange
+    # clouding would put CF back in the path and restore the 100MB upload cap and
+    # per-stream throttle this migration exists to avoid.
+    - dnsName: "sso.${SECRET_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "pangolin.${SECRET_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/identity/authentik/app/helmrelease.yaml
+++ b/kubernetes/apps/identity/authentik/app/helmrelease.yaml
@@ -123,7 +123,7 @@ spec:
             - name: internal
               namespace: network
               sectionName: https
-            - name: external
+            - name: external-pangolin
               namespace: network
               sectionName: https
           hostnames:

--- a/kubernetes/apps/identity/authentik/app/httproute-outpost.yaml
+++ b/kubernetes/apps/identity/authentik/app/httproute-outpost.yaml
@@ -23,7 +23,7 @@ spec:
     - name: internal
       namespace: network
       sectionName: https
-    - name: external
+    - name: external-pangolin
       namespace: network
       sectionName: https
   rules:

--- a/kubernetes/apps/identity/authentik/app/kustomization.yaml
+++ b/kubernetes/apps/identity/authentik/app/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ./helmrelease.yaml
   - ./httproute-outpost.yaml
   - ./referencegrant.yaml
+  - ./dnsendpoint.yaml
 components:
   - ../../../../components/externalsecret-refresh
 

--- a/kubernetes/apps/media/jellyseerr/app/dnsendpoint.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/dnsendpoint.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: jellyseerr
+spec:
+  endpoints:
+    # Public record points at the Pangolin VPS entry host instead of the
+    # Cloudflare tunnel. Only external-dns-cloudflare reads `crd` sources, so the
+    # LAN A record published from the `internal` Gateway is untouched and split
+    # horizon still sends on-network clients straight to Envoy.
+    #
+    # DNS-only (cloudflare-proxied: false) is required, not cosmetic: orange
+    # clouding would put CF back in the path and restore the 100MB upload cap and
+    # per-stream throttle this migration exists to avoid.
+    - dnsName: "requests.${SECRET_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "pangolin.${SECRET_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/helmrelease.yaml
@@ -89,7 +89,7 @@ spec:
           - name: internal
             namespace: network
             sectionName: https
-          - name: external
+          - name: external-pangolin
             namespace: network
             sectionName: https
         hostnames:

--- a/kubernetes/apps/media/jellyseerr/app/kustomization.yaml
+++ b/kubernetes/apps/media/jellyseerr/app/kustomization.yaml
@@ -5,6 +5,7 @@ kind: Kustomization
 resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
+  - ./dnsendpoint.yaml
 components:
   - ../../../../components/volsync
 

--- a/kubernetes/apps/network/echo-server/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/echo-server/app/dnsendpoint.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: echo-server-pangolin
+spec:
+  endpoints:
+    # Public record points at the Pangolin VPS entry host instead of the
+    # Cloudflare tunnel. Only external-dns-cloudflare reads `crd` sources, so the
+    # LAN A record published from the `internal` Gateway is untouched and split
+    # horizon still sends on-network clients straight to Envoy.
+    #
+    # DNS-only (cloudflare-proxied: false) is required, not cosmetic: orange
+    # clouding would put CF back in the path and restore the 100MB upload cap and
+    # per-stream throttle this migration exists to avoid.
+    - dnsName: "echo-server-pangolin.${SECRET_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "pangolin.${SECRET_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/network/echo-server/app/httproutes.yaml
+++ b/kubernetes/apps/network/echo-server/app/httproutes.yaml
@@ -9,7 +9,8 @@ metadata:
     gatus.home-operations.com/endpoint: |
       group: network
 spec:
-  hostnames: ["echo-server-external.${SECRET_DOMAIN}"]
+  hostnames:
+    - "echo-server-external.${SECRET_DOMAIN}"
   parentRefs:
     # External gateway - accessible via Cloudflare tunnel
     - name: external
@@ -34,7 +35,8 @@ metadata:
     gatus.home-operations.com/endpoint: |
       group: network
 spec:
-  hostnames: ["echo-server-internal.${SECRET_DOMAIN}"]
+  hostnames:
+    - "echo-server-internal.${SECRET_DOMAIN}"
   parentRefs:
     - name: internal
       namespace: network
@@ -56,7 +58,8 @@ metadata:
     gatus.home-operations.com/endpoint: |
       group: network
 spec:
-  hostnames: ["echo-server-external-sso.${SECRET_DOMAIN}"]
+  hostnames:
+    - "echo-server-external-sso.${SECRET_DOMAIN}"
   parentRefs:
     - name: external
       namespace: network
@@ -81,7 +84,8 @@ metadata:
     gatus.home-operations.com/endpoint: |
       group: network
 spec:
-  hostnames: ["echo-server-internal-sso.${SECRET_DOMAIN}"]
+  hostnames:
+    - "echo-server-internal-sso.${SECRET_DOMAIN}"
   parentRefs:
     - name: internal
       namespace: network
@@ -103,10 +107,36 @@ metadata:
     gatus.home-operations.com/endpoint: |
       group: network
 spec:
-  hostnames: ["echo-server-external-only.${SECRET_DOMAIN}"]
+  hostnames:
+    - "echo-server-external-only.${SECRET_DOMAIN}"
   parentRefs:
     # External gateway ONLY - no internal gateway reference
     - name: external
+      namespace: network
+      sectionName: https
+  rules:
+    - backendRefs:
+        - name: echo-server
+          port: 8080
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# Pangolin gateway ONLY - forces all traffic out to the Pangolin VPS and back in
+# through the Newt connector. No internal gateway reference on purpose: with one,
+# split-horizon DNS would answer on-network clients with the LAN A record and
+# they would never exercise the Pangolin path this probe exists to test.
+# Public record comes from ./dnsendpoint.yaml (CNAME -> pangolin.${SECRET_DOMAIN}).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: echo-server-pangolin
+  annotations:
+    gatus.home-operations.com/endpoint: |
+      group: network
+spec:
+  hostnames:
+    - "echo-server-pangolin.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: external-pangolin
       namespace: network
       sectionName: https
   rules:

--- a/kubernetes/apps/network/echo-server/app/kustomization.yaml
+++ b/kubernetes/apps/network/echo-server/app/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./ocirepository.yaml
   - ./helmrelease.yaml
   - ./httproutes.yaml
+  - ./dnsendpoint.yaml

--- a/kubernetes/apps/network/external-services/openspeedtest/app/dnsendpoint.yaml
+++ b/kubernetes/apps/network/external-services/openspeedtest/app/dnsendpoint.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: openspeedtest
+spec:
+  endpoints:
+    # Public record points at the Pangolin VPS entry host instead of the
+    # Cloudflare tunnel. Only external-dns-cloudflare reads `crd` sources, so the
+    # LAN A record published from the `internal` Gateway is untouched and split
+    # horizon still sends on-network clients straight to Envoy.
+    #
+    # DNS-only (cloudflare-proxied: false) is required, not cosmetic: orange
+    # clouding would put CF back in the path and restore the 100MB upload cap and
+    # per-stream throttle this migration exists to avoid.
+    - dnsName: "openspeedtest.${SECRET_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "pangolin.${SECRET_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/network/external-services/openspeedtest/app/httproute.yaml
+++ b/kubernetes/apps/network/external-services/openspeedtest/app/httproute.yaml
@@ -19,7 +19,7 @@ spec:
   hostnames:
     - "openspeedtest.${SECRET_DOMAIN}"
   parentRefs:
-    - name: external
+    - name: external-pangolin
       namespace: network
       sectionName: https
     - name: internal

--- a/kubernetes/apps/network/external-services/openspeedtest/app/kustomization.yaml
+++ b/kubernetes/apps/network/external-services/openspeedtest/app/kustomization.yaml
@@ -5,4 +5,5 @@ kind: Kustomization
 resources:
   - ./service.yaml
   - ./httproute.yaml
+  - ./dnsendpoint.yaml
 

--- a/kubernetes/apps/productivity/karakeep/app/dnsendpoint.yaml
+++ b/kubernetes/apps/productivity/karakeep/app/dnsendpoint.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: karakeep
+spec:
+  endpoints:
+    # Public record points at the Pangolin VPS entry host instead of the
+    # Cloudflare tunnel. Only external-dns-cloudflare reads `crd` sources, so the
+    # LAN A record published from the `internal` Gateway is untouched and split
+    # horizon still sends on-network clients straight to Envoy.
+    #
+    # DNS-only (cloudflare-proxied: false) is required, not cosmetic: orange
+    # clouding would put CF back in the path and restore the 100MB upload cap and
+    # per-stream throttle this migration exists to avoid.
+    - dnsName: "karakeep.${SECRET_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "pangolin.${SECRET_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/productivity/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/karakeep/app/helmrelease.yaml
@@ -178,7 +178,7 @@ spec:
           - name: internal
             namespace: network
             sectionName: https
-          - name: external
+          - name: external-pangolin
             namespace: network
             sectionName: https
         hostnames:

--- a/kubernetes/apps/productivity/karakeep/app/kustomization.yaml
+++ b/kubernetes/apps/productivity/karakeep/app/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
   - ./pvc.yaml
+  - ./dnsendpoint.yaml
 components:
   - ../../../../components/volsync
 

--- a/kubernetes/apps/productivity/mealie/app/dnsendpoint.yaml
+++ b/kubernetes/apps/productivity/mealie/app/dnsendpoint.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: mealie
+spec:
+  endpoints:
+    # Public record points at the Pangolin VPS entry host instead of the
+    # Cloudflare tunnel. Only external-dns-cloudflare reads `crd` sources, so the
+    # LAN A record published from the `internal` Gateway is untouched and split
+    # horizon still sends on-network clients straight to Envoy.
+    #
+    # DNS-only (cloudflare-proxied: false) is required, not cosmetic: orange
+    # clouding would put CF back in the path and restore the 100MB upload cap and
+    # per-stream throttle this migration exists to avoid.
+    - dnsName: "mealie.${SECRET_DOMAIN}"
+      recordType: CNAME
+      targets:
+        - "pangolin.${SECRET_DOMAIN}"
+      providerSpecific:
+        - name: external-dns.alpha.kubernetes.io/cloudflare-proxied
+          value: "false"

--- a/kubernetes/apps/productivity/mealie/app/helmrelease.yaml
+++ b/kubernetes/apps/productivity/mealie/app/helmrelease.yaml
@@ -103,7 +103,7 @@ spec:
           - name: internal
             namespace: network
             sectionName: https
-          - name: external
+          - name: external-pangolin
             namespace: network
             sectionName: https
         hostnames:

--- a/kubernetes/apps/productivity/mealie/app/kustomization.yaml
+++ b/kubernetes/apps/productivity/mealie/app/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ./ocirepository.yaml
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./dnsendpoint.yaml
 components:
   - ../../../../components/volsync
 


### PR DESCRIPTION
Second batch onto the Pangolin door, same pattern as Immich (#1564): `external` → `external-pangolin` parentRef, keep `internal` (split horizon holds), add an app-local DNSEndpoint → `CNAME pangolin.<domain>`, DNS-only.

| Host | App | Note |
|---|---|---|
| `sso` | identity/authentik | **two** routes (server + outpost) move together |
| `requests` | media/jellyseerr | |
| `karakeep` | productivity/karakeep | |
| `mealie` | productivity/mealie | |
| `couchdb` | database/couchdb | |
| `openspeedtest` | network/external-services | real bandwidth test of the VPS path |
| `echo-server-pangolin` | network/echo-server | **new** per-door probe |

## Notes
- **authentik must move as a pair** — the outpost serves `/outpost.goauthentik.io/*` for forward auth; splitting the two routes across doors half-breaks the SSO flow.
- **Forward auth is safe.** The authentik SecurityPolicies select by `matchLabels: auth=authentik` on HTTPRoutes, **not** by Gateway, so moving a route between doors preserves ext-auth. Verified before making the change.
- **echo-server-pangolin is intentionally pangolin-only** (no `internal` parentRef) — with one, split horizon would answer on-network clients with the LAN address and the probe would never test the Pangolin path.

## Tradeoff
External SSO now depends on the single Pangolin VPS; if it dies, external auth dies with it — including for apps still on the CF tunnel, which redirect users to `sso.<domain>`. Accepted deliberately. Per-app rollback = restore the `external` parentRef, drop that app's DNSEndpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)