### PR TITLE
feat(echo-server): page on Pangolin tunnel failure via gatus

### DIFF
--- a/kubernetes/apps/network/echo-server/app/httproutes.yaml
+++ b/kubernetes/apps/network/echo-server/app/httproutes.yaml
@@ -130,8 +130,16 @@ kind: HTTPRoute
 metadata:
   name: echo-server-pangolin
   annotations:
+    # Alerts are declared explicitly here because sidecar-discovered endpoints do
+    # NOT inherit one: the pushover `default-alert` in the gatus config only
+    # supplies defaults (thresholds, description) to endpoints that already
+    # declare `alerts:`, and only the hand-written endpoints in config.yaml do.
+    # Without this the probe would go red on the dashboard and never page --
+    # useless for the one thing it exists to catch, a broken Pangolin tunnel.
     gatus.home-operations.com/endpoint: |
       group: network
+      alerts:
+        - type: pushover
 spec:
   hostnames:
     - "echo-server-pangolin.${SECRET_DOMAIN}"


### PR DESCRIPTION
The `echo-server-pangolin` probe already tests the **full public path** — cluster DNS resolves it to the VPS (no `internal` parentRef ⇒ no LAN A record), so gatus goes out to Traefik → Gerbil/WireGuard → back in via Newt → `external-pangolin` gateway. Verified live: `200`, **~171ms** (vs ~30ms for internal paths).

**But it couldn't tell anyone when that broke.** Gatus only alerts on endpoints that declare `alerts:`. The pushover `default-alert` block supplies *defaults* (thresholds, description) to endpoints that already declare one — it does **not** attach an alert to everything. Only the hand-written endpoints in `config.yaml` declare one, and the sidecar adds no default, so every auto-discovered endpoint — this probe included — was dashboard-only.

This declares the pushover alert on that one route, inheriting the existing 5-failure / 2-success thresholds and `send-on-resolved`. Scoped to this probe only; adding alerts to all discovered endpoints would be large and noisy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)