### PR TITLE
fix(immich): raise ML sidecar memory to 12Gi to stop OOMKills during first-time backups

### DIFF
--- a/kubernetes/apps/media/immich/app/helmrelease.yaml
+++ b/kubernetes/apps/media/immich/app/helmrelease.yaml
@@ -90,9 +90,14 @@ spec:
             resources:
               requests:
                 cpu: 100m
-                memory: 512Mi
+                # ML holds a full copy of every active model per worker (3 workers:
+                # CLIP ViT-B-32, buffalo_l face det+rec, PP-OCRv5_server OCR). During
+                # first-time backups all three families load at once across all
+                # workers and peak well past the old 4Gi limit -> repeated OOMKills.
+                # Node has ~40Gi free, so give a generous ceiling for the ingest surge.
+                memory: 2Gi
               limits:
-                memory: 4Gi
+                memory: 12Gi
       # Microservices controller for background jobs
       microservices:
         type: deployment


### PR DESCRIPTION
## Problem

The `machine-learning` sidecar in `media/immich` was OOMKilled repeatedly (exit 137, 3x in ~10m) at its **4Gi** limit while two users ran first-time backups. With `MACHINE_LEARNING_WORKERS=3`, each worker holds its own copy of every active model family loaded concurrently during ingest:

- **CLIP** `ViT-B-32__openai` (smart search)
- **buffalo_l** face detection + recognition
- **PP-OCRv5_server** OCR (new/heavy in Immich v3.x)

Peak usage blew past 4Gi. The knock-on OCR job failures (`Machine learning request ... failed for all URLs`) were a symptom of the container being killed mid-request, not a separate fault.

## Change

- `machine-learning` limit **4Gi → 12Gi**, request **512Mi → 2Gi**.
- `app` container untouched (it was not OOMing).

brokkr02 has ~40Gi free (62Gi cap, ~34% used), so the 12Gi ceiling is comfortable for the ingest surge.

## Rollout

Live deployment was already patched to match for immediate relief — new pod is `2/2 Running`, 0 restarts. This PR persists it so Flux doesn't revert to 4Gi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)