### PR TITLE
feat(bluevulpine-blog): redirect retired valtrax subdomain to /chronicles/

### DIFF
--- a/kubernetes/apps/default/bluevulpine-blog/app/httproute.yaml
+++ b/kubernetes/apps/default/bluevulpine-blog/app/httproute.yaml
@@ -47,3 +47,34 @@ spec:
             scheme: https
             hostname: bluevulpine.net
             statusCode: 301
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+# valtrax.bluevulpine.net is a retired host that still appears as a dead link in
+# Miavir's story archive. Every path on it collapses onto the fiction index --
+# ReplaceFullPath rather than path-preserving, because none of the old valtrax
+# paths have an equivalent on the current site, so preserving them would just
+# trade a dead host for a 404.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: bluevulpine-blog-valtrax
+spec:
+  hostnames:
+    - "valtrax.bluevulpine.net"
+  parentRefs:
+    - name: external
+      namespace: network
+      sectionName: https
+    - name: internal
+      namespace: network
+      sectionName: https
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            hostname: bluevulpine.net
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /chronicles/
+            statusCode: 301


### PR DESCRIPTION
`valtrax.bluevulpine.net` is a dead host that still appears as a link in Miavir's story archive. Following one of those links currently returns NXDOMAIN — the reader hits a resolver failure instead of the fiction the link was pointing at.

Adds a redirect-only HTTPRoute in the same shape as the existing `www` → apex route.

### Notes

- **`ReplaceFullPath`, not path-preserving.** None of the old valtrax paths have an equivalent on the current site, so preserving them would trade a dead host for a 404.
- **301, not 302.** The host is permanently retired, so aggressive browser caching is a feature here.
- **No other change needed.** The wildcard cert already covers `*.bluevulpine.net`, cloudflared already routes `*.bluevulpine.net` to the external Gateway, and external-dns mints the proxied CNAME from this route's hostname.

### Considered and rejected: a `*.bluevulpine.net` catch-all

The open question was whether other forgotten subdomains are still being hit. They are not — Cloudflare DNS analytics over its retained 31 days shows no NXDOMAIN traffic on this zone beyond routine `_domainkey`/DKIM lookups. A wildcard would also make DNS a useless diagnostic on the zone, since every future hostname would resolve and 301 before being wired up.

### Verification

- `lefthook run pre-commit` — clean (`format-yaml`, `gitleaks`)
- Confirmed pre-merge that `valtrax`, `stories`, `archive`, `old` all NXDOMAIN, while explicitly-routed `www` and `onlyflans` resolve — so this route is additive and touches no existing hostname.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSfkkZcDBeE4Uw9T26bUTZ