### PR TITLE
fix(coredns,vmalert): stop acl blocking DNS cache prefetch; widen Gitea mirror alert

### DIFF
--- a/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
+++ b/kubernetes/apps/kube-system/coredns/app/helmrelease.yaml
@@ -27,9 +27,6 @@ spec:
             use_tcp: true
         port: 53
         plugins:
-          - name: acl # prevent ipv6 AAAA queries from resolving in-cluster
-            configBlock: |-
-              filter type AAAA
           - name: errors
           - name: health
             configBlock: |-
@@ -42,6 +39,41 @@ spec:
               fallthrough in-addr.arpa ip6.arpa
           - name: autopath
             parameters: "@kubernetes"
+          # Suppress AAAA cluster-wide: kopia resolves AAAA for R2 and then can't
+          # connect over IPv6 (original rationale, commit 6bb34324d). This replaces
+          # `acl { filter type AAAA }`, which achieved the same suppression but
+          # emitted ~14 errors/sec:
+          #   [ERROR] plugin/acl: Blocking request. Unable to parse source address:
+          #
+          # Measured on 2026-08-09 (5m rates, both pods):
+          #   coredns_acl_blocked_requests_total   14.266666666666666/s
+          #   coredns_cache_prefetch_total         14.266666666666666/s  (identical)
+          #   coredns_cache_served_stale_total     ~14.27/s
+          #   coredns_acl_filtered_requests_total   0.07/s
+          # The blocked and prefetch counters track each other exactly, and stale
+          # serving runs at the same rate. Client resolution was unaffected (60/60
+          # A lookups OK), so the blocked requests are not client queries.
+          #
+          # Inference (consistent with the above, not directly proven): acl rejects
+          # the cache plugin's background refreshes because they carry no parseable
+          # source address, so prefetch never completes, hot entries are never
+          # refreshed, and serve_stale silently covers for them. If so the cache is
+          # effectively stale-only, which would make a brief upstream DNS outage
+          # surface as a hard failure instead of being ridden out.
+          #
+          # template needs no source address, so it cannot hit that path. Client
+          # behaviour is unchanged — AAAA still returns NOERROR with an empty answer
+          # (verified before the change against cloudflare.com and google.com, which
+          # do publish AAAA records).
+          #
+          # VERIFY AFTER APPLY: coredns_acl_* series should disappear entirely, the
+          # [ERROR] plugin/acl log line should stop, and served_stale should fall
+          # well below prefetch. If served_stale still tracks prefetch 1:1, the
+          # inference above was wrong and prefetch is broken for another reason.
+          - name: template
+            parameters: ANY AAAA
+            configBlock: |-
+              rcode NOERROR
           - name: forward
             parameters: . /etc/resolv.conf
           - name: cache

--- a/kubernetes/apps/observability/vmalert/app/configmap.yaml
+++ b/kubernetes/apps/observability/vmalert/app/configmap.yaml
@@ -22,17 +22,37 @@ data:
             # `extract` pulls the repo slug out of the log line so `stats by (repo)`
             # yields one alert per failing repo (label `repo`) — naming exactly
             # which mirror is broken instead of a single aggregate count.
+            # Match on "[E]" rather than a specific failure string. This used to
+            # filter on "failed to update mirror repository", which silently missed
+            # the other shape Gitea emits — `remote URL is not allowed:
+            # migration/cloning from '<host>' is not allowed.` On 2026-08-09 three
+            # failures occurred but only one matched, so the alert under-reported
+            # (1 of 3) and the two hidden entries were the ones naming the real
+            # cause. Both shapes carry "[E]" and "SyncMirrors" and the same
+            # `[repo: <Repository N:owner/name>]` prefix, so extract still works.
             expr: >-
-              _time:1h app:gitea "SyncMirrors" "failed to update mirror repository"
+              _time:1h app:gitea "[E]" "SyncMirrors"
               | extract "Repository <repo_id>:<repo>>]"
               | stats by (repo) count() as failures | filter failures:>0
             labels:
               severity: warning
             annotations:
               summary: 'Gitea mirror sync failing: {{ $labels.repo }}'
+              # Check DNS before credentials. A failure to resolve the upstream host
+              # surfaces as `remote URL is not allowed: migration/cloning from
+              # 'github.com' is not allowed.` — which reads like an auth/policy
+              # problem but is not one. Gitea resolves the host and matches the
+              # returned IPs against its allow-list; an empty answer means no
+              # permitted IP, so it reports permission-denied. This annotation
+              # previously said "most often an expired credential", which sent the
+              # 2026-08-09 investigation toward rolling a perfectly good PAT.
               description: >-
                 {{ $labels.repo }} — {{ $value }} mirror sync failure(s) in the last
-                hour. This mirror can't pull from upstream — most often an expired
-                credential (e.g. a GitHub PAT). Fix: Gitea → this repo → Settings →
+                hour. This mirror can't pull from upstream. Check in this order:
+                (1) DNS — if the log says "Could not resolve host" or "remote URL is
+                not allowed", it is resolution, not auth; confirm with
+                `kubectl exec -n develop deploy/gitea -c gitea -- getent ahostsv4 github.com`
+                and check CoreDNS before touching any credential.
+                (2) Credential — only if DNS resolves: Gitea → this repo → Settings →
                 Mirror Settings → update the upstream credential. Logs: Grafana →
                 Explore → VictoriaLogs: app:gitea "[E]" "SyncMirrors"


### PR DESCRIPTION
Both changes came out of investigating a `GiteaMirrorSyncFailing` page. The alert said *"most often an expired credential (e.g. a GitHub PAT)"* — the token was fine. The mirror was failing to **resolve** `github.com`.

## 1. CoreDNS: `acl { filter type AAAA }` → `template ANY AAAA`

CoreDNS was emitting **~14 errors/sec, continuously**:

```
[ERROR] plugin/acl: Blocking request. Unable to parse source address:
```

Measured (5m rates, both pods):

| metric | rate |
|---|---|
| `coredns_acl_blocked_requests_total` | **14.266666666666666/s** |
| `coredns_cache_prefetch_total` | **14.266666666666666/s** ← identical |
| `coredns_cache_served_stale_total` | ~14.27/s |
| `coredns_acl_filtered_requests_total` | 0.07/s |

acl-blocked and cache-prefetch track each other **exactly**, and stale serving runs at the same rate. Client resolution was unaffected (60/60 A lookups OK), so the blocked requests aren't client queries — they're the cache's own background refreshes, which acl rejects because they carry no parseable source address.

So prefetch never completes, hot entries are never refreshed, and `serve_stale` silently covers. That's why this is worth fixing rather than just silencing: a cache that can only serve stale entries turns a brief upstream DNS blip into a hard failure once the stale window lapses — consistent with what took the mirror down.

`template` inspects no source address, so it can't reach that path.

**Behaviour is unchanged for clients.** AAAA still returns NOERROR with an empty answer — verified *before* the change against `cloudflare.com` and `google.com` (both publish AAAA records; `github.com` does not, so it's not a valid test). The original rationale from 6bb34324d (kopia resolving AAAA for R2 then failing to connect) is preserved.

Rendered Corefile verified with `helm template` against coredns chart 1.47.0:

```
    autopath @kubernetes
    template ANY AAAA {
        rcode NOERROR
    }
    forward . /etc/resolv.conf
```

`acl` gone, nothing else moved.

> **Caveat:** the causal link between acl and the blocked prefetches is a strong inference from an exact 1:1 correlation, **not a proof**. Post-apply verification is recorded inline in the HelmRelease: `coredns_acl_*` should disappear, the ERROR line should stop, and `served_stale` should fall well below `prefetch`. If `served_stale` still tracks `prefetch` 1:1 afterwards, the inference was wrong and prefetch is broken for another reason.

## 2. vmalert: the Gitea alert missed most failures and misdirected the fix

The expr filtered on `"failed to update mirror repository"` — only one of the two shapes Gitea emits. The other never matched:

```
remote URL is not allowed: migration/cloning from 'github.com' is not allowed.
```

On 2026-08-09 there were **3** failures; the alert reported **1** — and the two it hid were the ones naming the real cause. Verified against VictoriaLogs over the same 6h window:

```
old expr → 1
new expr → 3
```

Matching on `"[E]"` catches both shapes; both carry `"SyncMirrors"` and the same `[repo: <Repository N:owner/name>]` prefix, so `extract` is unchanged.

The description now says to check DNS **first** and only then the credential — that misleading line is what sent the investigation toward rolling a perfectly good PAT.

## Notes for review

- No cluster changes applied; this is config only, awaiting your review before go-live.
- Applying this rolls the CoreDNS pods. Cluster DNS is 2 replicas, so it should be a rolling restart, but it is worth watching.
- Unrelated but noticed: `bluevulpine.net.web` mirrors every **15 min** while all 7 other mirrors use the 8h default, which makes it the de-facto canary for any cluster DNS disruption. Not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFCSVLrdSmapBEVH6okkKf